### PR TITLE
Final update for 4.35

### DIFF
--- a/XA6_Inventory_V43.ps1
+++ b/XA6_Inventory_V43.ps1
@@ -142,11 +142,11 @@
 .PARAMETER StartDate
 	Start date, in MM/DD/YYYY HH:MM format, for the Configuration Logging report.
 	The default is today's date minus seven days.
-	If the StartDate is entered as 01/01/2020, the date becomes 01/01/2020 00:00:00.
+	If the StartDate is entered as 01/01/2022, the date becomes 01/01/2022 00:00:00.
 .PARAMETER EndDate
 	End date, in MM/DD/YYYY HH:MM format, for the Configuration Logging report.
 	The default is today's date.
-	If the EndDate is entered as 01/01/2020, the date becomes 01/01/2020 00:00:00.
+	If the EndDate is entered as 01/01/2022, the date becomes 01/01/2022 00:00:00.
 .PARAMETER Summary
 	Only give summary information, no details.
 	This parameter is disabled by default.
@@ -155,8 +155,8 @@
 .PARAMETER AddDateTime
 	Adds a date time stamp to the end of the file name.
 	Time stamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2020 at 6PM is 2020-06-01_1800.
-	Output filename will be ReportName_2020-06-01_1800.docx (or .pdf).
+	June 1, 2022 at 6PM is 2022-06-01_1800.
+	Output filename will be ReportName_2022-06-01_1800.docx (or .pdf).
 	This parameter is disabled by default.
 .PARAMETER Section
 	Processes a specific section of the report.
@@ -235,7 +235,7 @@
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
 .EXAMPLE
-	PS C:\PSScript > .\XA6_Inventory_V43.ps1 -StartDate "01/01/2020" -EndDate "01/02/2020" 
+	PS C:\PSScript > .\XA6_Inventory_V43.ps1 -StartDate "01/01/2022" -EndDate "01/02/2022" 
 	
 	Will use all Default values and add additional information for each server about its 
 	installed applications.
@@ -247,11 +247,11 @@
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
-	Will return all Configuration Logging entries from "01/01/2020 00:00:00" through 
-	"01/02/2020 "00:00:00".
+	Will return all Configuration Logging entries from "01/01/2022 00:00:00" through 
+	"01/02/2022 "00:00:00".
 .EXAMPLE
-	PS C:\PSScript > .\XA6_Inventory_V43.ps1 -StartDate "01/01/2020" -EndDate 
-	"01/01/2020" 
+	PS C:\PSScript > .\XA6_Inventory_V43.ps1 -StartDate "01/01/2022" -EndDate 
+	"01/01/2022" 
 	
 	Will use all Default values and add additional information for each server about its 
 	installed applications.
@@ -263,10 +263,10 @@
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
-	Will return all Configuration Logging entries from "01/01/2020 00:00:00" through 
-	"01/01/2020 "00:00:00".  In other words, nothing is returned.
+	Will return all Configuration Logging entries from "01/01/2022 00:00:00" through 
+	"01/01/2022 "00:00:00".  In other words, nothing is returned.
 .EXAMPLE
-	PS C:\PSScript > .\XA6_Inventory_V43.ps1 -StartDate "01/01/2020 21:00:00" -EndDate "01/01/2020 22:00:00" 
+	PS C:\PSScript > .\XA6_Inventory_V43.ps1 -StartDate "01/01/2022 21:00:00" -EndDate "01/01/2022 22:00:00" 
 	
 	Will use all Default values and add additional information for each server about its installed applications.
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
@@ -276,7 +276,7 @@
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
-	Will return all Configuration Logging entries from 9PM to 10PM on 01/01/2020.
+	Will return all Configuration Logging entries from 9PM to 10PM on 01/01/2022.
 .EXAMPLE
 	PS C:\PSScript .\XA6_Inventory_V43.ps1 -CompanyName "Carl Webster Consulting" 
 	-CoverPage "Mod" -UserName "Carl Webster"
@@ -349,8 +349,8 @@
 
 	Adds a date time stamp to the end of the file name.
 	Time stamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2020 at 6PM is 2020-06-01_1800.
-	Output filename will be XA6FarmName_2020-06-01_1800.docx
+	June 1, 2022 at 6PM is 2022-06-01_1800.
+	Output filename will be XA6FarmName_2022-06-01_1800.docx
 .EXAMPLE
 	PS C:\PSScript > .\XA6_Inventory_V43.ps1 -PDF -AddDateTime
 	
@@ -367,17 +367,17 @@
 
 	Adds a date time stamp to the end of the file name.
 	Time stamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2020 at 6PM is 2020-06-01_1800.
-	Output filename will be XA6FarmName_2020-06-01_1800.pdf
+	June 1, 2022 at 6PM is 2022-06-01_1800.
+	Output filename will be XA6FarmName_2022-06-01_1800.pdf
 .INPUTS
 	None.  You cannot pipe objects to this script.
 .OUTPUTS
 	No objects are output from this script.  This script creates a Word or PDF document.
 .NOTES
 	NAME: XA6_Inventory_V43.ps1
-	VERSION: 4.34
+	VERSION: 4.35
 	AUTHOR: Carl Webster (with a lot of help from Michael B. Smith, Jeff Wouters and Iain Brighton)
-	LASTEDIT: May 9, 2020
+	LASTEDIT: April 23, 2022
 #>
 
 
@@ -467,6 +467,28 @@ Param(
 #http://www.CarlWebster.com
 #originally released to the Citrix community on September 30, 2011
 
+#Version 4.35 23-Apr-2022
+#	Change all Get-WMIObject to Get-CIMInstance
+#	Fixed numerous $Null comparisons
+#	Fixed the German Table of Contents (Thanks to Rene Bigler)
+#		From 
+#			'de-'	{ 'Automatische Tabelle 2'; Break }
+#		To
+#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
+#	General code cleanup
+#	In Function AbortScript, add test for the winword process and terminate it if it is running
+#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
+#	In Function OutputNicItem, fixed several issues with DHCP data
+#	Updated the following functions to the latest version:
+#		AddWordTable
+#		Check-LoadedModule
+#		Check-NeededPSSnapins
+#		SetWordCellFormat
+#		UpdateDocumentProperties
+#		validStateProp
+#	Updated the help text
+#	Updated the ReadMe file
+#
 #Version 4.34 9-May-2020
 #	Add checking for a Word version of 0, which indicates the Office installation needs repairing
 #	Add Receive Side Scaling setting to Function OutputNICItem
@@ -571,7 +593,7 @@ $PSDefaultParameterValues = @{"*:Verbose"=$True}
 $SaveEAPreference = $ErrorActionPreference
 $ErrorActionPreference = 'SilentlyContinue'
 
-If($MSWord -eq $Null)
+If($Null -eq $MSWord)
 {
 	If($PDF)
 	{
@@ -602,11 +624,11 @@ Else
 {
 	$ErrorActionPreference = $SaveEAPreference
 	Write-Verbose "$(Get-Date): Unable to determine output parameter"
-	If($MSWord -eq $Null)
+	If($Null -eq $MSWord)
 	{
 		Write-Verbose "$(Get-Date): MSWord is Null"
 	}
-	ElseIf($PDF -eq $Null)
+	ElseIf($Null -eq $PDF)
 	{
 		Write-Verbose "$(Get-Date): PDF is Null"
 	}
@@ -630,16 +652,16 @@ Else
 $ValidSection = $False
 Switch ($Section)
 {
-	"Admins" {$ValidSection = $True}
-	"Apps" {$ValidSection = $True}
-	"ConfigLog" {$ValidSection = $True}
-	"LBPolicies" {$ValidSection = $True}
-	"LoadEvals" {$ValidSection = $True}
-	"Policies" {$ValidSection = $True}
-	"Servers" {$ValidSection = $True}
-	"WGs" {$ValidSection = $True}
-	"Zones" {$ValidSection = $True}
-	"All" {$ValidSection = $True}
+	"Admins"		{$ValidSection = $True}
+	"Apps"			{$ValidSection = $True}
+	"ConfigLog"		{$ValidSection = $True}
+	"LBPolicies"	{$ValidSection = $True}
+	"LoadEvals"		{$ValidSection = $True}
+	"Policies"		{$ValidSection = $True}
+	"Servers"		{$ValidSection = $True}
+	"WGs"			{$ValidSection = $True}
+	"Zones"			{$ValidSection = $True}
+	"All"			{$ValidSection = $True}
 }
 
 If($ValidSection -eq $False)
@@ -688,7 +710,7 @@ If($MSWord -or $PDF)
 	[int]$wdSeekPrimaryFooter = 4
 	[int]$wdStory = 6
 	[int]$wdColorRed = 255
-	[int]$wdColorBlack = 0
+	#[int]$wdColorBlack = 0
 	[int]$wdWord2007 = 12
 	[int]$wdWord2010 = 14
 	[int]$wdWord2013 = 15
@@ -697,29 +719,29 @@ If($MSWord -or $PDF)
 	[int]$wdFormatPDF = 17
 	#http://blogs.technet.com/b/heyscriptingguy/archive/2006/03/01/how-can-i-right-align-a-single-column-in-a-word-table.aspx
 	#http://msdn.microsoft.com/en-us/library/office/ff835817%28v=office.15%29.aspx
-	[int]$wdAlignParagraphLeft = 0
-	[int]$wdAlignParagraphCenter = 1
-	[int]$wdAlignParagraphRight = 2
+	#[int]$wdAlignParagraphLeft = 0
+	#[int]$wdAlignParagraphCenter = 1
+	#[int]$wdAlignParagraphRight = 2
 	#http://msdn.microsoft.com/en-us/library/office/ff193345%28v=office.15%29.aspx
-	[int]$wdCellAlignVerticalTop = 0
-	[int]$wdCellAlignVerticalCenter = 1
-	[int]$wdCellAlignVerticalBottom = 2
+	#[int]$wdCellAlignVerticalTop = 0
+	#[int]$wdCellAlignVerticalCenter = 1
+	#[int]$wdCellAlignVerticalBottom = 2
 	#http://msdn.microsoft.com/en-us/library/office/ff844856%28v=office.15%29.aspx
 	[int]$wdAutoFitFixed = 0
 	[int]$wdAutoFitContent = 1
-	[int]$wdAutoFitWindow = 2
+	#[int]$wdAutoFitWindow = 2
 	#http://msdn.microsoft.com/en-us/library/office/ff821928%28v=office.15%29.aspx
 	[int]$wdAdjustNone = 0
 	[int]$wdAdjustProportional = 1
-	[int]$wdAdjustFirstColumn = 2
-	[int]$wdAdjustSameWidth = 3
+	#[int]$wdAdjustFirstColumn = 2
+	#[int]$wdAdjustSameWidth = 3
 
 	[int]$PointsPerTabStop = 36
 	[int]$Indent0TabStops = 0 * $PointsPerTabStop
 	[int]$Indent1TabStops = 1 * $PointsPerTabStop
 	[int]$Indent2TabStops = 2 * $PointsPerTabStop
 	[int]$Indent3TabStops = 3 * $PointsPerTabStop
-	[int]$Indent4TabStops = 4 * $PointsPerTabStop
+	#[int]$Indent4TabStops = 4 * $PointsPerTabStop
 
 	# http://www.thedoctools.com/index.php?show=wt_style_names_english_danish_german_french
 	[int]$wdStyleHeading1 = -2
@@ -734,12 +756,12 @@ If($MSWord -or $PDF)
 	[int]$wdLineStyleSingle = 1
 
 	[int]$wdHeadingFormatTrue = -1
-	[int]$wdHeadingFormatFalse = 0 
+	#[int]$wdHeadingFormatFalse = 0 
 
-	[string]$RunningOS = (Get-WmiObject -class Win32_OperatingSystem -EA 0).Caption
+	[string]$RunningOS = (Get-CIMInstance -ClassName Win32_OperatingSystem -EA 0 -Verbose:$False).Caption
 }
 
-#region code for -hardware switch
+#region code for hardware data
 Function GetComputerWMIInfo
 {
 	Param([string]$RemoteComputerName)
@@ -750,21 +772,29 @@ Function GetComputerWMIInfo
 	# @kbaggerman on Twitter
 	# http://blog.myvirtualvision.com
 	# modified 1-May-2014 to work in trusted AD Forests and using different domain admin credentials	
+	# modified 17-Aug-2016 to fix a few issues with Text and HTML output
+	# modified 29-Apr-2018 to change from Arrays to New-Object System.Collections.ArrayList
+	# modified 11-Mar-2022 changed from using Get-WmiObject to Get-CimInstance
 
 	#Get Computer info
-	Write-Verbose "$(Get-Date): `t`tProcessing WMI Computer information"
-	Write-Verbose "$(Get-Date): `t`t`tHardware information"
+	Write-Verbose "$(Get-Date -Format G): `t`tProcessing WMI Computer information"
+	Write-Verbose "$(Get-Date -Format G): `t`t`tHardware information"
 	If($MSWord -or $PDF)
 	{
 		WriteWordLine 3 0 "Computer Information: $($RemoteComputerName)"
 		WriteWordLine 4 0 "General Computer"
 	}
 	
-	[bool]$GotComputerItems = $True
-	
 	Try
 	{
-		$Results = Get-WmiObject -computername $RemoteComputerName win32_computersystem
+		If($RemoteComputerName -eq $env:computername)
+		{
+			$Results = Get-CimInstance -ClassName win32_computersystem -Verbose:$False
+		}
+		Else
+		{
+			$Results = Get-CimInstance -computername $RemoteComputerName -ClassName win32_computersystem -Verbose:$False
+		}
 	}
 	
 	Catch
@@ -772,33 +802,38 @@ Function GetComputerWMIInfo
 		$Results = $Null
 	}
 	
-	If($? -and $Results -ne $Null)
+	If($? -and $Null -ne $Results)
 	{
-		$ComputerItems = $Results | Select Manufacturer, Model, Domain, `
+		$ComputerItems = $Results | Select-Object Manufacturer, Model, Domain, `
 		@{N="TotalPhysicalRam"; E={[math]::round(($_.TotalPhysicalMemory / 1GB),0)}}, `
 		NumberOfProcessors, NumberOfLogicalProcessors
 		$Results = $Null
+		If($RemoteComputerName -eq $env:computername)
+		{
+			[string]$ComputerOS = (Get-CimInstance -ClassName Win32_OperatingSystem -EA 0 -Verbose:$False).Caption
+		}
+		Else
+		{
+			[string]$ComputerOS = (Get-CimInstance -ClassName Win32_OperatingSystem -CimSession $RemoteComputerName -EA 0 -Verbose:$False).Caption
+		}
 
 		ForEach($Item in $ComputerItems)
 		{
-			OutputComputerItem $Item
+			OutputComputerItem $Item $ComputerOS $RemoteComputerName
 		}
 	}
 	ElseIf(!$?)
 	{
-		Write-Verbose "$(Get-Date): Get-WmiObject win32_computersystem failed for $($RemoteComputerName)"
-		Write-Warning "Get-WmiObject win32_computersystem failed for $($RemoteComputerName)"
+		Write-Verbose "$(Get-Date -Format G): Get-CimInstance win32_computersystem failed for $($RemoteComputerName)"
+		Write-Warning "Get-CimInstance win32_computersystem failed for $($RemoteComputerName)"
 		If($MSWORD -or $PDF)
 		{
-			WriteWordLine 0 2 "Get-WmiObject win32_computersystem failed for $($RemoteComputerName)" "" $Null 0 $False $True
-			WriteWordLine 0 2 "On $($RemoteComputerName) you may need to run winmgmt /verifyrepository" "" $Null 0 $False $True
-			WriteWordLine 0 2 "and winmgmt /salvagerepository.  If this is a trusted Forest, you may" "" $Null 0 $False $True
-			WriteWordLine 0 2 "need to rerun the script with Domain Admin credentials from the trusted Forest." "" $Null 0 $False $True
+			WriteWordLine 0 2 "Get-CimInstance win32_computersystem failed for $($RemoteComputerName)" "" $Null 0 $False $True
 		}
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): No results Returned for Computer information"
+		Write-Verbose "$(Get-Date -Format G): No results Returned for Computer information"
 		If($MSWORD -or $PDF)
 		{
 			WriteWordLine 0 2 "No results Returned for Computer information" "" $Null 0 $False $True
@@ -806,18 +841,23 @@ Function GetComputerWMIInfo
 	}
 	
 	#Get Disk info
-	Write-Verbose "$(Get-Date): `t`t`tDrive information"
+	Write-Verbose "$(Get-Date -Format G): `t`t`tDrive information"
 
 	If($MSWord -or $PDF)
 	{
 		WriteWordLine 4 0 "Drive(s)"
 	}
 
-	[bool]$GotDrives = $True
-	
 	Try
 	{
-		$Results = Get-WmiObject -computername $RemoteComputerName Win32_LogicalDisk
+		If($RemoteComputerName -eq $env:computername)
+		{
+			$Results = Get-CimInstance -ClassName Win32_LogicalDisk -Verbose:$False
+		}
+		Else
+		{
+			$Results = Get-CimInstance -CimSession $RemoteComputerName -ClassName Win32_LogicalDisk -Verbose:$False
+		}
 	}
 	
 	Catch
@@ -825,9 +865,9 @@ Function GetComputerWMIInfo
 		$Results = $Null
 	}
 
-	If($? -and $Results -ne $Null)
+	If($? -and $Null -ne $Results)
 	{
-		$drives = $Results | Select caption, @{N="drivesize"; E={[math]::round(($_.size / 1GB),0)}}, 
+		$drives = $Results | Select-Object caption, @{N="drivesize"; E={[math]::round(($_.size / 1GB),0)}}, 
 		filesystem, @{N="drivefreespace"; E={[math]::round(($_.freespace / 1GB),0)}}, 
 		volumename, drivetype, volumedirty, volumeserialnumber
 		$Results = $Null
@@ -841,39 +881,40 @@ Function GetComputerWMIInfo
 	}
 	ElseIf(!$?)
 	{
-		Write-Verbose "$(Get-Date): Get-WmiObject Win32_LogicalDisk failed for $($RemoteComputerName)"
-		Write-Warning "Get-WmiObject Win32_LogicalDisk failed for $($RemoteComputerName)"
+		Write-Verbose "$(Get-Date -Format G): Get-CimInstance Win32_LogicalDisk failed for $($RemoteComputerName)"
+		Write-Warning "Get-CimInstance Win32_LogicalDisk failed for $($RemoteComputerName)"
 		If($MSWORD -or $PDF)
 		{
-			WriteWordLine 0 2 "Get-WmiObject Win32_LogicalDisk failed for $($RemoteComputerName)" "" $Null 0 $False $True
-			WriteWordLine 0 2 "On $($RemoteComputerName) you may need to run winmgmt /verifyrepository" "" $Null 0 $False $True
-			WriteWordLine 0 2 "and winmgmt /salvagerepository.  If this is a trusted Forest, you may" "" $Null 0 $False $True
-			WriteWordLine 0 2 "need to rerun the script with Domain Admin credentials from the trusted Forest." "" $Null 0 $False $True
+			WriteWordLine 0 2 "Get-CimInstance Win32_LogicalDisk failed for $($RemoteComputerName)" "" $Null 0 $False $True
 		}
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): No results Returned for Drive information"
+		Write-Verbose "$(Get-Date -Format G): No results Returned for Drive information"
 		If($MSWORD -or $PDF)
 		{
 			WriteWordLine 0 2 "No results Returned for Drive information" "" $Null 0 $False $True
 		}
 	}
 	
-
 	#Get CPU's and stepping
-	Write-Verbose "$(Get-Date): `t`t`tProcessor information"
+	Write-Verbose "$(Get-Date -Format G): `t`t`tProcessor information"
 
 	If($MSWord -or $PDF)
 	{
 		WriteWordLine 4 0 "Processor(s)"
 	}
 
-	[bool]$GotProcessors = $True
-	
 	Try
 	{
-		$Results = Get-WmiObject -computername $RemoteComputerName win32_Processor
+		If($RemoteComputerName -eq $env:computername)
+		{
+			$Results = Get-CimInstance -ClassName win32_Processor -Verbose:$False
+		}
+		Else
+		{
+			$Results = Get-CimInstance -computername $RemoteComputerName -ClassName win32_Processor -Verbose:$False
+		}
 	}
 	
 	Catch
@@ -881,9 +922,9 @@ Function GetComputerWMIInfo
 		$Results = $Null
 	}
 
-	If($? -and $Results -ne $Null)
+	If($? -and $Null -ne $Results)
 	{
-		$Processors = $Results | Select availability, name, description, maxclockspeed, 
+		$Processors = $Results | Select-Object availability, name, description, maxclockspeed, 
 		l2cachesize, l3cachesize, numberofcores, numberoflogicalprocessors
 		$Results = $Null
 		ForEach($processor in $processors)
@@ -893,19 +934,16 @@ Function GetComputerWMIInfo
 	}
 	ElseIf(!$?)
 	{
-		Write-Verbose "$(Get-Date): Get-WmiObject win32_Processor failed for $($RemoteComputerName)"
-		Write-Warning "Get-WmiObject win32_Processor failed for $($RemoteComputerName)"
+		Write-Verbose "$(Get-Date -Format G): Get-CimInstance win32_Processor failed for $($RemoteComputerName)"
+		Write-Warning "Get-CimInstance win32_Processor failed for $($RemoteComputerName)"
 		If($MSWORD -or $PDF)
 		{
-			WriteWordLine 0 2 "Get-WmiObject win32_Processor failed for $($RemoteComputerName)" "" $Null 0 $False $True
-			WriteWordLine 0 2 "On $($RemoteComputerName) you may need to run winmgmt /verifyrepository" "" $Null 0 $False $True
-			WriteWordLine 0 2 "and winmgmt /salvagerepository.  If this is a trusted Forest, you may" "" $Null 0 $False $True
-			WriteWordLine 0 2 "need to rerun the script with Domain Admin credentials from the trusted Forest." "" $Null 0 $False $True
+			WriteWordLine 0 2 "Get-CimInstance win32_Processor failed for $($RemoteComputerName)" "" $Null 0 $False $True
 		}
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): No results Returned for Processor information"
+		Write-Verbose "$(Get-Date -Format G): No results Returned for Processor information"
 		If($MSWORD -or $PDF)
 		{
 			WriteWordLine 0 2 "No results Returned for Processor information" "" $Null 0 $False $True
@@ -913,7 +951,7 @@ Function GetComputerWMIInfo
 	}
 
 	#Get Nics
-	Write-Verbose "$(Get-Date): `t`t`tNIC information"
+	Write-Verbose "$(Get-Date -Format G): `t`t`tNIC information"
 
 	If($MSWord -or $PDF)
 	{
@@ -924,26 +962,33 @@ Function GetComputerWMIInfo
 	
 	Try
 	{
-		$Results = Get-WmiObject -computername $RemoteComputerName win32_networkadapterconfiguration
+		If($RemoteComputerName -eq $env:computername)
+		{
+			$Results = Get-CimInstance -ClassName win32_networkadapterconfiguration -Verbose:$False
+		}
+		Else
+		{
+			$Results = Get-CimInstance -computername $RemoteComputerName -ClassName win32_networkadapterconfiguration -Verbose:$False
+		}
 	}
 	
 	Catch
 	{
-		$Results
+		$Results = $Null
 	}
 
-	If($? -and $Results -ne $Null)
+	If($? -and $Null -ne $Results)
 	{
-		$Nics = $Results | Where {$_.ipaddress -ne $Null}
+		$Nics = $Results | Where-Object {$Null -ne $_.ipaddress}
 		$Results = $Null
 
-		If($Nics -eq $Null ) 
+		If($Null -eq $Nics) 
 		{ 
 			$GotNics = $False 
 		} 
 		Else 
 		{ 
-			$GotNics = !($Nics.__PROPERTY_COUNT -eq 0) 
+			$GotNics = $True
 		} 
 	
 		If($GotNics)
@@ -952,7 +997,14 @@ Function GetComputerWMIInfo
 			{
 				Try
 				{
-					$ThisNic = Get-WmiObject -computername $RemoteComputerName win32_networkadapter | Where {$_.index -eq $nic.index}
+					If($RemoteComputerName -eq $env:computername)
+					{
+						$ThisNic = Get-CimInstance -ClassName win32_networkadapter -Verbose:$False | Where-Object {$_.index -eq $nic.index}
+					}
+					Else
+					{
+						$ThisNic = Get-CimInstance -computername $RemoteComputerName -ClassName win32_networkadapter -Verbose:$False | Where-Object {$_.index -eq $nic.index}
+					}
 				}
 				
 				Catch 
@@ -960,27 +1012,23 @@ Function GetComputerWMIInfo
 					$ThisNic = $Null
 				}
 				
-				If($? -and $ThisNic -ne $Null)
+				If($? -and $Null -ne $ThisNic)
 				{
 					OutputNicItem $Nic $ThisNic $RemoteComputerName
 				}
 				ElseIf(!$?)
 				{
 					Write-Warning "$(Get-Date): Error retrieving NIC information"
-					Write-Verbose "$(Get-Date): Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)"
-					Write-Warning "Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)"
+					Write-Verbose "$(Get-Date -Format G): Get-CimInstance win32_networkadapterconfiguration failed for $($RemoteComputerName)"
+					Write-Warning "Get-CimInstance win32_networkadapterconfiguration failed for $($RemoteComputerName)"
 					If($MSWORD -or $PDF)
 					{
 						WriteWordLine 0 2 "Error retrieving NIC information" "" $Null 0 $False $True
-						WriteWordLine 0 2 "Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)" "" $Null 0 $False $True
-						WriteWordLine 0 2 "On $($RemoteComputerName) you may need to run winmgmt /verifyrepository" "" $Null 0 $False $True
-						WriteWordLine 0 2 "and winmgmt /salvagerepository.  If this is a trusted Forest, you may" "" $Null 0 $False $True
-						WriteWordLine 0 2 "need to rerun the script with Domain Admin credentials from the trusted Forest." "" $Null 0 $False $True
 					}
 				}
 				Else
 				{
-					Write-Verbose "$(Get-Date): No results Returned for NIC information"
+					Write-Verbose "$(Get-Date -Format G): No results Returned for NIC information"
 					If($MSWORD -or $PDF)
 					{
 						WriteWordLine 0 2 "No results Returned for NIC information" "" $Null 0 $False $True
@@ -992,20 +1040,16 @@ Function GetComputerWMIInfo
 	ElseIf(!$?)
 	{
 		Write-Warning "$(Get-Date): Error retrieving NIC configuration information"
-		Write-Verbose "$(Get-Date): Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)"
-		Write-Warning "Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)"
+		Write-Verbose "$(Get-Date -Format G): Get-CimInstance win32_networkadapterconfiguration failed for $($RemoteComputerName)"
+		Write-Warning "Get-CimInstance win32_networkadapterconfiguration failed for $($RemoteComputerName)"
 		If($MSWORD -or $PDF)
 		{
 			WriteWordLine 0 2 "Error retrieving NIC configuration information" "" $Null 0 $False $True
-			WriteWordLine 0 2 "Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)" "" $Null 0 $False $True
-			WriteWordLine 0 2 "On $($RemoteComputerName) you may need to run winmgmt /verifyrepository" "" $Null 0 $False $True
-			WriteWordLine 0 2 "and winmgmt /salvagerepository.  If this is a trusted Forest, you may" "" $Null 0 $False $True
-			WriteWordLine 0 2 "need to rerun the script with Domain Admin credentials from the trusted Forest." "" $Null 0 $False $True
 		}
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): No results Returned for NIC configuration information"
+		Write-Verbose "$(Get-Date -Format G): No results Returned for NIC configuration information"
 		If($MSWORD -or $PDF)
 		{
 			WriteWordLine 0 2 "No results Returned for NIC configuration information" "" $Null 0 $False $True
@@ -1016,29 +1060,54 @@ Function GetComputerWMIInfo
 	{
 		WriteWordLine 0 0 ""
 	}
-
-	$Results = $Null
-	$ComputerItems = $Null
-	$Drives = $Null
-	$Processors = $Null
-	$Nics = $Null
 }
 
 Function OutputComputerItem
 {
-	Param([object]$Item)
+	Param([object]$Item, [string]$OS, [string]$RemoteComputerName)
+	
+	#get computer's power plan
+	#https://techcommunity.microsoft.com/t5/core-infrastructure-and-security/get-the-active-power-plan-of-multiple-servers-with-powershell/ba-p/370429
+	
+	try 
+	{
+
+		If($RemoteComputerName -eq $env:computername)
+		{
+			$PowerPlan = (Get-CimInstance -ClassName Win32_PowerPlan -Namespace "root\cimv2\power" -Verbose:$False |
+				Where-Object {$_.IsActive -eq $true} |
+				Select-Object @{Name = "PowerPlan"; Expression = {$_.ElementName}}).PowerPlan
+		}
+		Else
+		{
+			$PowerPlan = (Get-CimInstance -CimSession $RemoteComputerName -ClassName Win32_PowerPlan -Namespace "root\cimv2\power" -Verbose:$False |
+				Where-Object {$_.IsActive -eq $true} |
+				Select-Object @{Name = "PowerPlan"; Expression = {$_.ElementName}}).PowerPlan
+		}
+	}
+
+	catch 
+	{
+
+		$PowerPlan = $_.Exception
+
+	}	
+	
 	If($MSWord -or $PDF)
 	{
-		[System.Collections.Hashtable[]] $ItemInformation = @()
-		$ItemInformation += @{ Data = "Manufacturer"; Value = $Item.manufacturer; }
-		$ItemInformation += @{ Data = "Model"; Value = $Item.model; }
-		$ItemInformation += @{ Data = "Domain"; Value = $Item.domain; }
-		$ItemInformation += @{ Data = "Total Ram"; Value = "$($Item.totalphysicalram) GB"; }
-		$ItemInformation += @{ Data = "Physical Processors (sockets)"; Value = $Item.NumberOfProcessors; }
-		$ItemInformation += @{ Data = "Logical Processors (cores w/HT)"; Value = $Item.NumberOfLogicalProcessors; }
+		$ItemInformation = New-Object System.Collections.ArrayList
+		$ItemInformation.Add(@{ Data = "Manufacturer"; Value = $Item.manufacturer; }) > $Null
+		$ItemInformation.Add(@{ Data = "Model"; Value = $Item.model; }) > $Null
+		$ItemInformation.Add(@{ Data = "Domain"; Value = $Item.domain; }) > $Null
+		$ItemInformation.Add(@{ Data = "Operating System"; Value = $OS; }) > $Null
+		$ItemInformation.Add(@{ Data = "Power Plan"; Value = $PowerPlan; }) > $Null
+		$ItemInformation.Add(@{ Data = "Total Ram"; Value = "$($Item.totalphysicalram) GB"; }) > $Null
+		$ItemInformation.Add(@{ Data = "Physical Processors (sockets)"; Value = $Item.NumberOfProcessors; }) > $Null
+		$ItemInformation.Add(@{ Data = "Logical Processors (cores w/HT)"; Value = $Item.NumberOfLogicalProcessors; }) > $Null
 		$Table = AddWordTable -Hashtable $ItemInformation `
 		-Columns Data,Value `
 		-List `
+		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
 		## Set first column format
@@ -1052,7 +1121,7 @@ Function OutputComputerItem
 
 		FindWordDocumentEnd
 		$Table = $Null
-		WriteWordLine 0 2 ""
+		WriteWordLine 0 0 ""
 	}
 }
 
@@ -1063,14 +1132,14 @@ Function OutputDriveItem
 	$xDriveType = ""
 	Switch ($drive.drivetype)
 	{
-		0	{$xDriveType = "Unknown"}
-		1	{$xDriveType = "No Root Directory"}
-		2	{$xDriveType = "Removable Disk"}
-		3	{$xDriveType = "Local Disk"}
-		4	{$xDriveType = "Network Drive"}
-		5	{$xDriveType = "Compact Disc"}
-		6	{$xDriveType = "RAM Disk"}
-		Default {$xDriveType = "Unknown"}
+		0		{$xDriveType = "Unknown"; Break}
+		1		{$xDriveType = "No Root Directory"; Break}
+		2		{$xDriveType = "Removable Disk"; Break}
+		3		{$xDriveType = "Local Disk"; Break}
+		4		{$xDriveType = "Network Drive"; Break}
+		5		{$xDriveType = "Compact Disc"; Break}
+		6		{$xDriveType = "RAM Disk"; Break}
+		Default {$xDriveType = "Unknown"; Break}
 	}
 	
 	$xVolumeDirty = ""
@@ -1088,30 +1157,31 @@ Function OutputDriveItem
 
 	If($MSWORD -or $PDF)
 	{
-		[System.Collections.Hashtable[]] $DriveInformation = @()
-		$DriveInformation += @{ Data = "Caption"; Value = $Drive.caption; }
-		$DriveInformation += @{ Data = "Size"; Value = "$($drive.drivesize) GB"; }
+		$DriveInformation = New-Object System.Collections.ArrayList
+		$DriveInformation.Add(@{ Data = "Caption"; Value = $Drive.caption; }) > $Null
+		$DriveInformation.Add(@{ Data = "Size"; Value = "$($drive.drivesize) GB"; }) > $Null
 		If(![String]::IsNullOrEmpty($drive.filesystem))
 		{
-			$DriveInformation += @{ Data = "File System"; Value = $Drive.filesystem; }
+			$DriveInformation.Add(@{ Data = "File System"; Value = $Drive.filesystem; }) > $Null
 		}
-		$DriveInformation += @{ Data = "Free Space"; Value = "$($drive.drivefreespace) GB"; }
+		$DriveInformation.Add(@{ Data = "Free Space"; Value = "$($drive.drivefreespace) GB"; }) > $Null
 		If(![String]::IsNullOrEmpty($drive.volumename))
 		{
-			$DriveInformation += @{ Data = "Volume Name"; Value = $Drive.volumename; }
+			$DriveInformation.Add(@{ Data = "Volume Name"; Value = $Drive.volumename; }) > $Null
 		}
 		If(![String]::IsNullOrEmpty($drive.volumedirty))
 		{
-			$DriveInformation += @{ Data = "Volume is Dirty"; Value = $xVolumeDirty; }
+			$DriveInformation.Add(@{ Data = "Volume is Dirty"; Value = $xVolumeDirty; }) > $Null
 		}
 		If(![String]::IsNullOrEmpty($drive.volumeserialnumber))
 		{
-			$DriveInformation += @{ Data = "Volume Serial Number"; Value = $Drive.volumeserialnumber; }
+			$DriveInformation.Add(@{ Data = "Volume Serial Number"; Value = $Drive.volumeserialnumber; }) > $Null
 		}
-		$DriveInformation += @{ Data = "Drive Type"; Value = $xDriveType; }
+		$DriveInformation.Add(@{ Data = "Drive Type"; Value = $xDriveType; }) > $Null
 		$Table = AddWordTable -Hashtable $DriveInformation `
 		-Columns Data,Value `
 		-List `
+		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
 		## Set first column format
@@ -1138,52 +1208,53 @@ Function OutputProcessorItem
 	$xAvailability = ""
 	Switch ($processor.availability)
 	{
-		1	{$xAvailability = "Other"}
-		2	{$xAvailability = "Unknown"}
-		3	{$xAvailability = "Running or Full Power"}
-		4	{$xAvailability = "Warning"}
-		5	{$xAvailability = "In Test"}
-		6	{$xAvailability = "Not Applicable"}
-		7	{$xAvailability = "Power Off"}
-		8	{$xAvailability = "Off Line"}
-		9	{$xAvailability = "Off Duty"}
-		10	{$xAvailability = "Degraded"}
-		11	{$xAvailability = "Not Installed"}
-		12	{$xAvailability = "Install Error"}
-		13	{$xAvailability = "Power Save - Unknown"}
-		14	{$xAvailability = "Power Save - Low Power Mode"}
-		15	{$xAvailability = "Power Save - Standby"}
-		16	{$xAvailability = "Power Cycle"}
-		17	{$xAvailability = "Power Save - Warning"}
-		Default	{$xAvailability = "Unknown"}
+		1		{$xAvailability = "Other"; Break}
+		2		{$xAvailability = "Unknown"; Break}
+		3		{$xAvailability = "Running or Full Power"; Break}
+		4		{$xAvailability = "Warning"; Break}
+		5		{$xAvailability = "In Test"; Break}
+		6		{$xAvailability = "Not Applicable"; Break}
+		7		{$xAvailability = "Power Off"; Break}
+		8		{$xAvailability = "Off Line"; Break}
+		9		{$xAvailability = "Off Duty"; Break}
+		10		{$xAvailability = "Degraded"; Break}
+		11		{$xAvailability = "Not Installed"; Break}
+		12		{$xAvailability = "Install Error"; Break}
+		13		{$xAvailability = "Power Save - Unknown"; Break}
+		14		{$xAvailability = "Power Save - Low Power Mode"; Break}
+		15		{$xAvailability = "Power Save - Standby"; Break}
+		16		{$xAvailability = "Power Cycle"; Break}
+		17		{$xAvailability = "Power Save - Warning"; Break}
+		Default	{$xAvailability = "Unknown"; Break}
 	}
 
 	If($MSWORD -or $PDF)
 	{
-		[System.Collections.Hashtable[]] $ProcessorInformation = @()
-		$ProcessorInformation += @{ Data = "Name"; Value = $Processor.name; }
-		$ProcessorInformation += @{ Data = "Description"; Value = $Processor.description; }
-		$ProcessorInformation += @{ Data = "Max Clock Speed"; Value = "$($processor.maxclockspeed) MHz"; }
+		$ProcessorInformation = New-Object System.Collections.ArrayList
+		$ProcessorInformation.Add(@{ Data = "Name"; Value = $Processor.name; }) > $Null
+		$ProcessorInformation.Add(@{ Data = "Description"; Value = $Processor.description; }) > $Null
+		$ProcessorInformation.Add(@{ Data = "Max Clock Speed"; Value = "$($processor.maxclockspeed) MHz"; }) > $Null
 		If($processor.l2cachesize -gt 0)
 		{
-			$ProcessorInformation += @{ Data = "L2 Cache Size"; Value = "$($processor.l2cachesize) KB"; }
+			$ProcessorInformation.Add(@{ Data = "L2 Cache Size"; Value = "$($processor.l2cachesize) KB"; }) > $Null
 		}
 		If($processor.l3cachesize -gt 0)
 		{
-			$ProcessorInformation += @{ Data = "L3 Cache Size"; Value = "$($processor.l3cachesize) KB"; }
+			$ProcessorInformation.Add(@{ Data = "L3 Cache Size"; Value = "$($processor.l3cachesize) KB"; }) > $Null
 		}
 		If($processor.numberofcores -gt 0)
 		{
-			$ProcessorInformation += @{ Data = "Number of Cores"; Value = $Processor.numberofcores; }
+			$ProcessorInformation.Add(@{ Data = "Number of Cores"; Value = $Processor.numberofcores; }) > $Null
 		}
 		If($processor.numberoflogicalprocessors -gt 0)
 		{
-			$ProcessorInformation += @{ Data = "Number of Logical Processors (cores w/HT)"; Value = $Processor.numberoflogicalprocessors; }
+			$ProcessorInformation.Add(@{ Data = "Number of Logical Processors (cores w/HT)"; Value = $Processor.numberoflogicalprocessors; }) > $Null
 		}
-		$ProcessorInformation += @{ Data = "Availability"; Value = $xAvailability; }
+		$ProcessorInformation.Add(@{ Data = "Availability"; Value = $xAvailability; }) > $Null
 		$Table = AddWordTable -Hashtable $ProcessorInformation `
 		-Columns Data,Value `
 		-List `
+		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
 		## Set first column format
@@ -1205,7 +1276,16 @@ Function OutputNicItem
 {
 	Param([object]$Nic, [object]$ThisNic, [string]$RemoteComputerName)
 	
-	$powerMgmt = Get-WmiObject -computername $RemoteComputerName MSPower_DeviceEnable -Namespace root\wmi | Where-Object{$_.InstanceName -match [regex]::Escape($ThisNic.PNPDeviceID)}
+	If($RemoteComputerName -eq $env:computername)
+	{
+		$powerMgmt = Get-CimInstance -ClassName MSPower_DeviceEnable -Namespace "root\wmi" -Verbose:$False |
+			Where-Object{$_.InstanceName -match [regex]::Escape($ThisNic.PNPDeviceID)}
+	}
+	Else
+	{
+		$powerMgmt = Get-CimInstance -CimSession $RemoteComputerName -ClassName MSPower_DeviceEnable -Namespace "root\wmi" -Verbose:$False |
+			Where-Object{$_.InstanceName -match [regex]::Escape($ThisNic.PNPDeviceID)}
+	}
 
 	If($? -and $Null -ne $powerMgmt)
 	{
@@ -1213,7 +1293,7 @@ Function OutputNicItem
 		{
 			$PowerSaving = "Enabled"
 		}
-		Else
+		Else	
 		{
 			$PowerSaving = "Disabled"
 		}
@@ -1251,13 +1331,20 @@ Function OutputNicItem
 	Try
 	{
 		#https://ios.developreference.com/article/10085450/How+do+I+enable+VRSS+(Virtual+Receive+Side+Scaling)+for+a+Windows+VM+without+relying+on+Enable-NetAdapterRSS%3F
-		$RSSEnabled = (Get-WmiObject -ComputerName $RemoteComputerName MSFT_NetAdapterRssSettingData -Namespace "root\StandardCimV2" -ea 0).Enabled
+		If($RemoteComputerName -eq $env:computername)
+		{
+			$RSSEnabled = (Get-CimInstance -ClassName MSFT_NetAdapterRssSettingData -Namespace "root\StandardCimV2" -ea 0 -Verbose:$False).Enabled
+		}
+		Else
+		{
+			$RSSEnabled = (Get-CimInstance -CimSession $RemoteComputerName -ClassName MSFT_NetAdapterRssSettingData -Namespace "root\StandardCimV2" -ea 0 -Verbose:$False).Enabled
+		}
 
 		If($RSSEnabled)
 		{
 			$RSSEnabled = "Enabled"
 		}
-		ELse
+		Else
 		{
 			$RSSEnabled = "Disabled"
 		}
@@ -1265,38 +1352,38 @@ Function OutputNicItem
 	
 	Catch
 	{
-		$RSSEnabled = "Not available on $Script:RunningOS"
+		$RSSEnabled = "Unable to determine for $RemoteComputerName"
 	}
 
-	$xIPAddress = @()
+	$xIPAddress = New-Object System.Collections.ArrayList
 	ForEach($IPAddress in $Nic.ipaddress)
 	{
-		$xIPAddress += "$($IPAddress)"
+		$xIPAddress.Add("$($IPAddress)") > $Null
 	}
 
-	$xIPSubnet = @()
+	$xIPSubnet = New-Object System.Collections.ArrayList
 	ForEach($IPSubnet in $Nic.ipsubnet)
 	{
-		$xIPSubnet += "$($IPSubnet)"
+		$xIPSubnet.Add("$($IPSubnet)") > $Null
 	}
 
-	If($nic.dnsdomainsuffixsearchorder -ne $Null -and $nic.dnsdomainsuffixsearchorder.length -gt 0)
+	If($Null -ne $nic.dnsdomainsuffixsearchorder -and $nic.dnsdomainsuffixsearchorder.length -gt 0)
 	{
 		$nicdnsdomainsuffixsearchorder = $nic.dnsdomainsuffixsearchorder
-		$xnicdnsdomainsuffixsearchorder = @()
+		$xnicdnsdomainsuffixsearchorder = New-Object System.Collections.ArrayList
 		ForEach($DNSDomain in $nicdnsdomainsuffixsearchorder)
 		{
-			$xnicdnsdomainsuffixsearchorder += "$($DNSDomain)"
+			$xnicdnsdomainsuffixsearchorder.Add("$($DNSDomain)") > $Null
 		}
 	}
 	
-	If($nic.dnsserversearchorder -ne $Null -and $nic.dnsserversearchorder.length -gt 0)
+	If($Null -ne $nic.dnsserversearchorder -and $nic.dnsserversearchorder.length -gt 0)
 	{
 		$nicdnsserversearchorder = $nic.dnsserversearchorder
-		$xnicdnsserversearchorder = @()
+		$xnicdnsserversearchorder = New-Object System.Collections.ArrayList
 		ForEach($DNSServer in $nicdnsserversearchorder)
 		{
-			$xnicdnsserversearchorder += "$($DNSServer)"
+			$xnicdnsserversearchorder.Add("$($DNSServer)") > $Null
 		}
 	}
 
@@ -1313,10 +1400,10 @@ Function OutputNicItem
 	$xTcpipNetbiosOptions = ""
 	Switch ($nic.TcpipNetbiosOptions)
 	{
-		0	{$xTcpipNetbiosOptions = "Use NetBIOS setting from DHCP Server"}
-		1	{$xTcpipNetbiosOptions = "Enable NetBIOS"}
-		2	{$xTcpipNetbiosOptions = "Disable NetBIOS"}
-		Default	{$xTcpipNetbiosOptions = "Unknown"}
+		0		{$xTcpipNetbiosOptions = "Use NetBIOS setting from DHCP Server"; Break}
+		1		{$xTcpipNetbiosOptions = "Enable NetBIOS"; Break}
+		2		{$xTcpipNetbiosOptions = "Disable NetBIOS"; Break}
+		Default	{$xTcpipNetbiosOptions = "Unknown"; Break}
 	}
 	
 	$xwinsenablelmhostslookup = ""
@@ -1329,101 +1416,116 @@ Function OutputNicItem
 		$xwinsenablelmhostslookup = "No"
 	}
 
+	If($nic.dhcpenabled)
+	{
+		$DHCPLeaseObtainedDate = $nic.dhcpleaseobtained.ToLocalTime()
+		$DHCPLeaseExpiresDate = $nic.dhcpleaseexpires.ToLocalTIme()
+	}
+		
 	If($MSWORD -or $PDF)
 	{
-		[System.Collections.Hashtable[]] $NicInformation = @()
-		$NicInformation += @{ Data = "Name"; Value = $ThisNic.Name; }
+		$NicInformation = New-Object System.Collections.ArrayList
+		$NicInformation.Add(@{ Data = "Name"; Value = $ThisNic.Name; }) > $Null
 		If($ThisNic.Name -ne $nic.description)
 		{
-			$NicInformation += @{ Data = "Description"; Value = $Nic.description; }
+			$NicInformation.Add(@{ Data = "Description"; Value = $Nic.description; }) > $Null
 		}
-		$NicInformation += @{ Data = "Connection ID"; Value = $ThisNic.NetConnectionID; }
-		$NicInformation += @{ Data = "Manufacturer"; Value = $Nic.manufacturer; }
-		$NicInformation += @{ Data = "Availability"; Value = $xAvailability; }
-		$NicInformation += @{ Data = "Allow the computer to turn off this device to save power"; Value = $PowerSaving; }
-		$NicInformation += @{ Data = "Receive Side Scaling"; Value = $RSSEnabled; }
-		$NicInformation += @{ Data = "Physical Address"; Value = $Nic.macaddress; }
+		$NicInformation.Add(@{ Data = "Connection ID"; Value = $ThisNic.NetConnectionID; }) > $Null
+		If(validObject $Nic Manufacturer)
+		{
+			$NicInformation.Add(@{ Data = "Manufacturer"; Value = $Nic.manufacturer; }) > $Null
+		}
+		$NicInformation.Add(@{ Data = "Availability"; Value = $xAvailability; }) > $Null
+		$NicInformation.Add(@{ Data = "Allow the computer to turn off this device to save power"; Value = $PowerSaving; }) > $Null
+		$NicInformation.Add(@{ Data = "Receive Side Scaling"; Value = $RSSEnabled; }) > $Null
+		$NicInformation.Add(@{ Data = "Physical Address"; Value = $Nic.macaddress; }) > $Null
 		If($xIPAddress.Count -gt 1)
 		{
-			$NicInformation += @{ Data = "IP Address"; Value = $xIPAddress[0]; }
-			$NicInformation += @{ Data = "Default Gateway"; Value = $Nic.Defaultipgateway; }
-			$NicInformation += @{ Data = "Subnet Mask"; Value = $xIPSubnet[0]; }
+			$NicInformation.Add(@{ Data = "IP Address"; Value = $xIPAddress[0]; }) > $Null
+			$NicInformation.Add(@{ Data = "Default Gateway"; Value = $Nic.Defaultipgateway; }) > $Null
+			$NicInformation.Add(@{ Data = "Subnet Mask"; Value = $xIPSubnet[0]; }) > $Null
 			$cnt = -1
 			ForEach($tmp in $xIPAddress)
 			{
 				$cnt++
 				If($cnt -gt 0)
 				{
-					$NicInformation += @{ Data = "IP Address"; Value = $tmp; }
-					$NicInformation += @{ Data = "Subnet Mask"; Value = $xIPSubnet[$cnt]; }
+					$NicInformation.Add(@{ Data = "IP Address"; Value = $tmp; }) > $Null
+					$NicInformation.Add(@{ Data = "Subnet Mask"; Value = $xIPSubnet[$cnt]; }) > $Null
 				}
 			}
 		}
 		Else
 		{
-			$NicInformation += @{ Data = "IP Address"; Value = $xIPAddress; }
-			$NicInformation += @{ Data = "Default Gateway"; Value = $Nic.Defaultipgateway; }
-			$NicInformation += @{ Data = "Subnet Mask"; Value = $xIPSubnet; }
+			$NicInformation.Add(@{ Data = "IP Address"; Value = $xIPAddress; }) > $Null
+			$NicInformation.Add(@{ Data = "Default Gateway"; Value = $Nic.Defaultipgateway; }) > $Null
+			$NicInformation.Add(@{ Data = "Subnet Mask"; Value = $xIPSubnet; }) > $Null
 		}
 		If($nic.dhcpenabled)
 		{
-			$DHCPLeaseObtainedDate = $nic.ConvertToDateTime($nic.dhcpleaseobtained)
-			$DHCPLeaseExpiresDate = $nic.ConvertToDateTime($nic.dhcpleaseexpires)
-			$NicInformation += @{ Data = "DHCP Enabled"; Value = $Nic.dhcpenabled; }
-			$NicInformation += @{ Data = "DHCP Lease Obtained"; Value = $dhcpleaseobtaineddate; }
-			$NicInformation += @{ Data = "DHCP Lease Expires"; Value = $dhcpleaseexpiresdate; }
-			$NicInformation += @{ Data = "DHCP Server"; Value = $Nic.dhcpserver; }
+			$NicInformation.Add(@{ Data = "DHCP Enabled"; Value = $Nic.dhcpenabled.ToString(); }) > $Null
+			$NicInformation.Add(@{ Data = "DHCP Lease Obtained"; Value = $dhcpleaseobtaineddate; }) > $Null
+			$NicInformation.Add(@{ Data = "DHCP Lease Expires"; Value = $dhcpleaseexpiresdate; }) > $Null
+			$NicInformation.Add(@{ Data = "DHCP Server"; Value = $Nic.dhcpserver; }) > $Null
+		}
+		Else
+		{
+			$NicInformation.Add(@{ Data = "DHCP Enabled"; Value = $Nic.dhcpenabled.ToString(); }) > $Null
 		}
 		If(![String]::IsNullOrEmpty($nic.dnsdomain))
 		{
-			$NicInformation += @{ Data = "DNS Domain"; Value = $Nic.dnsdomain; }
+			$NicInformation.Add(@{ Data = "DNS Domain"; Value = $Nic.dnsdomain; }) > $Null
 		}
-		If($nic.dnsdomainsuffixsearchorder -ne $Null -and $nic.dnsdomainsuffixsearchorder.length -gt 0)
+		If($Null -ne $nic.dnsdomainsuffixsearchorder -and $nic.dnsdomainsuffixsearchorder.length -gt 0)
 		{
-			$NicInformation += @{ Data = "DNS Search Suffixes"; Value = $xnicdnsdomainsuffixsearchorder[0]; }
+			$NicInformation.Add(@{ Data = "DNS Search Suffixes"; Value = $xnicdnsdomainsuffixsearchorder[0]; }) > $Null
 			$cnt = -1
 			ForEach($tmp in $xnicdnsdomainsuffixsearchorder)
 			{
 				$cnt++
 				If($cnt -gt 0)
 				{
-					$NicInformation += @{ Data = ""; Value = $tmp; }
+					$NicInformation.Add(@{ Data = ""; Value = $tmp; }) > $Null
 				}
 			}
 		}
-		$NicInformation += @{ Data = "DNS WINS Enabled"; Value = $xdnsenabledforwinsresolution; }
-		If($nic.dnsserversearchorder -ne $Null -and $nic.dnsserversearchorder.length -gt 0)
+		$NicInformation.Add(@{ Data = "DNS WINS Enabled"; Value = $xdnsenabledforwinsresolution; }) > $Null
+		If($Null -ne $nic.dnsserversearchorder -and $nic.dnsserversearchorder.length -gt 0)
 		{
-			$NicInformation += @{ Data = "DNS Servers"; Value = $xnicdnsserversearchorder[0]; }
+			$NicInformation.Add(@{ Data = "DNS Servers"; Value = $xnicdnsserversearchorder[0]; }) > $Null
 			$cnt = -1
 			ForEach($tmp in $xnicdnsserversearchorder)
 			{
 				$cnt++
 				If($cnt -gt 0)
 				{
-					$NicInformation += @{ Data = ""; Value = $tmp; }
+					$NicInformation.Add(@{ Data = ""; Value = $tmp; }) > $Null
 				}
 			}
 		}
-		$NicInformation += @{ Data = "NetBIOS Setting"; Value = $xTcpipNetbiosOptions; }
-		$NicInformation += @{ Data = "WINS: Enabled LMHosts"; Value = $xwinsenablelmhostslookup; }
+		$NicInformation.Add(@{ Data = "NetBIOS Setting"; Value = $xTcpipNetbiosOptions; }) > $Null
+		$NicInformation.Add(@{ Data = "WINS: Enabled LMHosts"; Value = $xwinsenablelmhostslookup; }) > $Null
 		If(![String]::IsNullOrEmpty($nic.winshostlookupfile))
 		{
-			$NicInformation += @{ Data = "Host Lookup File"; Value = $Nic.winshostlookupfile; }
+			$NicInformation.Add(@{ Data = "Host Lookup File"; Value = $Nic.winshostlookupfile; }) > $Null
 		}
 		If(![String]::IsNullOrEmpty($nic.winsprimaryserver))
 		{
-			$NicInformation += @{ Data = "Primary Server"; Value = $Nic.winsprimaryserver; }
+			$NicInformation.Add(@{ Data = "Primary Server"; Value = $Nic.winsprimaryserver; }) > $Null
 		}
 		If(![String]::IsNullOrEmpty($nic.winssecondaryserver))
 		{
-			$NicInformation += @{ Data = "Secondary Server"; Value = $Nic.winssecondaryserver; }
+			$NicInformation.Add(@{ Data = "Secondary Server"; Value = $Nic.winssecondaryserver; }) > $Null
 		}
 		If(![String]::IsNullOrEmpty($nic.winsscopeid))
 		{
-			$NicInformation += @{ Data = "Scope ID"; Value = $Nic.winsscopeid; }
+			$NicInformation.Add(@{ Data = "Scope ID"; Value = $Nic.winsscopeid; }) > $Null
 		}
-		$Table = AddWordTable -Hashtable $NicInformation -Columns Data,Value -List -AutoFit $wdAutoFitFixed;
+		$Table = AddWordTable -Hashtable $NicInformation `
+		-Columns Data,Value `
+		-List `
+		-Format $wdTableGrid `
+		-AutoFit $wdAutoFitFixed;
 
 		## Set first column format
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
@@ -1436,6 +1538,7 @@ Function OutputNicItem
 
 		FindWordDocumentEnd
 		$Table = $Null
+		WriteWordLine 0 0 ""
 	}
 }
 #endregion
@@ -1473,7 +1576,7 @@ Function SetWordHashTable
 		{
 			'ca-'	{ 'Taula automática 2'; Break }
 			'da-'	{ 'Automatisk tabel 2'; Break }
-			'de-'	{ 'Automatische Tabelle 2'; Break }
+			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
 			'en-'	{ 'Automatic Table 2'; Break }
 			'es-'	{ 'Tabla automática 2'; Break }
 			'fi-'	{ 'Automaattinen taulukko 2'; Break }
@@ -1839,7 +1942,7 @@ Function SWExclusions
 	$var = ""
 	$Tmp = '$InstalledApps | Where {'
 	$Exclusions = Get-Content "$($pwd.path)\SoftwareExclusions.txt" -EA 0
-	If($? -and $Exclusions -ne $Null)
+	If($? -and $Null -ne $Exclusions)
 	{
 		If($Exclusions -is [array])	
 		{
@@ -1865,20 +1968,29 @@ Function CheckWordPrereq
 	If((Test-Path  REGISTRY::HKEY_CLASSES_ROOT\Word.Application) -eq $False)
 	{
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Host "`n`n`t`tThis script directly outputs to Microsoft Word, please install Microsoft Word`n`n"
-		Exit
+		
+		If(($MSWord -eq $False) -and ($PDF -eq $True))
+		{
+			Write-Host "`n`n`t`tThis script uses Microsoft Word's SaveAs PDF function, please install Microsoft Word`n`n"
+			AbortScript
+		}
+		Else
+		{
+			Write-Host "`n`n`t`tThis script directly outputs to Microsoft Word, please install Microsoft Word`n`n"
+			AbortScript
+		}
 	}
 
 	#find out our session (usually "1" except on TS/RDC or Citrix)
 	$SessionID = (Get-Process -PID $PID).SessionId
 	
 	#Find out if winword is running in our session
-	[bool]$wordrunning = ((Get-Process 'WinWord' -ea 0)|?{$_.SessionId -eq $SessionID}) -ne $Null
+	[bool]$wordrunning = $null –ne ((Get-Process 'WinWord' -ea 0) | Where-Object {$_.SessionId -eq $SessionID})
 	If($wordrunning)
 	{
 		$ErrorActionPreference = $SaveEAPreference
 		Write-Host "`n`n`tPlease close all instances of Microsoft Word before running this report.`n`n"
-		Exit
+		AbortScript
 	}
 }
 
@@ -2000,9 +2112,9 @@ Function Check-LoadedModule
 
 {
 	Param([parameter(Mandatory = $True)][alias("Module")][string]$ModuleName)
-	#$LoadedModules = Get-Module | Select Name
+	#$LoadedModules = Get-Module | Select-Object Name
 	#following line changed at the recommendation of @andyjmorgan
-	$LoadedModules = Get-Module |% { $_.Name.ToString() }
+	$LoadedModules = Get-Module | ForEach-Object { $_.Name.ToString() }
 	#bug reported on 21-JAN-2013 by @schose 
 	#the following line did not work if the citrix.grouppolicy.commands.psm1 module
 	#was manually loaded from a non Default folder
@@ -2041,10 +2153,10 @@ Function Check-NeededPSSnapins
 	$RegisteredSnapins = @()
 
 	#Creates arrays of strings, rather than objects, we're passing strings so this will be more robust.
-	$loadedSnapins += Get-pssnapin | % {$_.name}
-	$registeredSnapins += Get-pssnapin -Registered | % {$_.name}
+	$loadedSnapins += Get-PSSnapin | ForEach-Object {$_.name}
+	$registeredSnapins += Get-PSSnapin -Registered | ForEach-Object {$_.name}
 
-	ForEach ($Snapin in $Snapins)
+	ForEach($Snapin in $Snapins)
 	{
 		#check if the snapin is loaded
 		If(!($LoadedSnapins -like $snapin))
@@ -2064,7 +2176,18 @@ Function Check-NeededPSSnapins
 			{
 				#Snapin is registered, but not loaded, loading it now:
 				Write-Host "Loading Windows PowerShell snap-in: $snapin"
-				Add-PSSnapin -Name $snapin -EA 0 *>$Null
+				Add-PSSnapin -Name $snapin -EA 0
+
+				If(!($?))
+				{
+					Write-Error "
+	`n`n
+	Error loading snapin: $($error[0].Exception.Message)
+	`n`n
+	Script cannot continue.
+	`n`n"
+					Return $false
+				}				
 			}
 		}
 	}
@@ -2072,8 +2195,10 @@ Function Check-NeededPSSnapins
 	If($FoundMissingSnapin)
 	{
 		Write-Warning "Missing Windows PowerShell snap-ins Detected:"
-		$missingSnapins | % {Write-Warning "($_)"}
-		return $False
+		Write-Host ""
+		$missingSnapins | ForEach-Object {Write-Host "`tMissing Snapin: ($_)"}
+		Write-Host ""
+		Return $False
 	}
 	Else
 	{
@@ -2192,16 +2317,30 @@ Function Set-DocumentProperty {
 
 Function AbortScript
 {
-	$Script:Word.quit()
-	Write-Verbose "$(Get-Date): System Cleanup"
-	[System.Runtime.Interopservices.Marshal]::ReleaseComObject($Script:Word) | Out-Null
+	Write-Verbose "$(Get-Date -Format G): System Cleanup"
 	If(Test-Path variable:global:word)
 	{
+		$Script:Word.quit()
+		[System.Runtime.Interopservices.Marshal]::ReleaseComObject($Script:Word) | Out-Null
 		Remove-Variable -Name word -Scope Global 4>$Null
 	}
 	[gc]::collect() 
 	[gc]::WaitForPendingFinalizers()
-	Write-Verbose "$(Get-Date): Script has been aborted"
+
+	#is the winword Process still running? kill it
+
+	#find out our session (usually "1" except on TS/RDC or Citrix)
+	$SessionID = (Get-Process -PID $PID).SessionId
+
+	#Find out if winword running in our session
+	$wordprocess = ((Get-Process 'WinWord' -ea 0) | Where-Object {$_.SessionId -eq $SessionID}) | Select-Object -Property Id 
+	If( $wordprocess -and $wordprocess.Id -gt 0)
+	{
+		Write-Verbose "$(Get-Date -Format G): WinWord Process is still running. Attempting to stop WinWord Process # $($wordprocess.Id)"
+		Stop-Process $wordprocess.Id -EA 0
+	}
+	
+	Write-Verbose "$(Get-Date -Format G): Script has been aborted"
 	$ErrorActionPreference = $SaveEAPreference
 	Exit
 }
@@ -2224,11 +2363,11 @@ Function ProcessCitrixPolicies
 		{
 			WriteWordLine 0 0 ""
 			WriteWordLine 0 0 "IMA Policies"
-			$Policies = Get-CtxGroupPolicy -EA 0 | Sort Type,PolicyName
+			$Policies = Get-CtxGroupPolicy -EA 0 | Sort-Object Type,PolicyName
 		}
 		Else
 		{
-			$Policies = Get-CtxGroupPolicy -EA 0 | Sort Type,Priority
+			$Policies = Get-CtxGroupPolicy -EA 0 | Sort-Object Type,Priority
 		}
 	}
 	Else
@@ -2237,15 +2376,15 @@ Function ProcessCitrixPolicies
 		{
 			WriteWordLine 0 0 ""
 			WriteWordLine 0 0 "Active Directory Policies"
-			$Policies = Get-CtxGroupPolicy -DriveName $xDriveName -EA 0 | Sort Type,PolicyName
+			$Policies = Get-CtxGroupPolicy -DriveName $xDriveName -EA 0 | Sort-Object Type,PolicyName
 		}
 		Else
 		{
-			$Policies = Get-CtxGroupPolicy -DriveName $xDriveName -EA 0 | Sort Type,Priority
+			$Policies = Get-CtxGroupPolicy -DriveName $xDriveName -EA 0 | Sort-Object Type,Priority
 		}
 	}
 
-	If($? -and $Policies -ne $Null)
+	If($? -and $Null -ne $Policies)
 	{
 		ForEach($Policy in $Policies)
 		{
@@ -2360,7 +2499,7 @@ Function ProcessCitrixPolicies
 					$Settings = Get-CtxGroupPolicyConfiguration -PolicyName $Policy.PolicyName -DriveName $xDriveName -EA 0
 				}
 
-				If($? -and $Settings -ne $Null)
+				If($? -and $Null -ne $Settings)
 				{
 					ForEach($Setting in $Settings)
 					{
@@ -2620,7 +2759,7 @@ Function ProcessCitrixPolicies
 								$XML = $Null
 								$xRow = $Null
 								$Columns = $Null
-								$Row = $Null
+								$Rows = $Null
 							}
 							If($Setting.MaximumServersOfflinePercent.State -ne "NotConfigured")
 							{
@@ -3676,31 +3815,31 @@ Function GetCtxGPOsInAD
 {
 	#thanks to the Citrix Engineering Team for pointers and for Michael B. Smith for creating the function
 	#updated 07-Nov-13 to work in a Windows Workgroup environment
-	Write-Verbose "$(Get-Date): Testing for an Active Directory environment"
+	Write-Verbose "$(Get-Date -Format G): Testing for an Active Directory environment"
 	$root = [ADSI]"LDAP://RootDSE"
 	If([String]::IsNullOrEmpty($root.PSBase.Name))
 	{
-		Write-Verbose "$(Get-Date): Not in an Active Directory environment"
+		Write-Verbose "$(Get-Date -Format G): `tNot in an Active Directory environment"
 		$root = $Null
 		$xArray = @()
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): In an Active Directory environment"
+		Write-Verbose "$(Get-Date -Format G): `tIn an Active Directory environment"
 		$domainNC = $root.defaultNamingContext.ToString()
 		$root = $Null
 		$xArray = @()
 
 		$domain = $domainNC.Replace( 'DC=', '' ).Replace( ',', '.' )
-		Write-Verbose "$(Get-Date): Searching \\$($domain)\sysvol\$($domain)\Policies"
+		Write-Verbose "$(Get-Date -Format G): `tSearching \\$($domain)\sysvol\$($domain)\Policies"
 		$sysvolFiles = @()
-		$sysvolFiles = dir -Recurse ( '\\' + $domain  + '\sysvol\' + $domain + '\Policies' ) -EA 0
+		$sysvolFiles = Get-ChildItem -Recurse ( '\\' + $domain  + '\sysvol\' + $domain + '\Policies' ) -EA 0
 		If($sysvolFiles.Count -eq 0)
 		{
-			Write-Verbose "$(Get-Date): Search timed out.  Retrying.  Searching \\ + $($domain)\sysvol\$($domain)\Policies a second time."
-			$sysvolFiles = dir -Recurse ( '\\' + $domain  + '\sysvol\' + $domain + '\Policies' ) -EA 0
+			Write-Verbose "$(Get-Date -Format G): `tSearch timed out. Retrying. Searching \\ + $($domain)\sysvol\$($domain)\Policies a second time."
+			$sysvolFiles = Get-ChildItem -Recurse ( '\\' + $domain  + '\sysvol\' + $domain + '\Policies' ) -EA 0
 		}
-		foreach( $file in $sysvolFiles )
+		ForEach( $file in $sysvolFiles )
 		{
 			If( -not $file.PSIsContainer )
 			{
@@ -3713,7 +3852,10 @@ Function GetCtxGPOsInAD
 					{
 						$gp = $array[ 6 ].ToString()
 						$gpObject = [ADSI]( "LDAP://" + "CN=" + $gp + ",CN=Policies,CN=System," + $domainNC )
-						$xArray += $gpObject.DisplayName	### name of the group policy object
+						If(!$xArray.Contains($gpObject.DisplayName))
+						{
+							$xArray += $gpObject.DisplayName	### name of the group policy object
+						}
 					}
 				}
 			}
@@ -3850,37 +3992,38 @@ Function AddWordTable
 	Param
 	(
 		# Array of Hashtable (including table headers)
-		[Parameter(Mandatory=$true, ValueFromPipelineByPropertyName=$true, ParameterSetName='Hashtable', Position=0)]
+		[Parameter(Mandatory=$True, ValueFromPipelineByPropertyName=$True, ParameterSetName='Hashtable', Position=0)]
 		[ValidateNotNullOrEmpty()] [System.Collections.Hashtable[]] $Hashtable,
 		# Array of PSCustomObjects
-		[Parameter(Mandatory=$true, ValueFromPipelineByPropertyName=$true, ParameterSetName='CustomObject', Position=0)]
+		[Parameter(Mandatory=$True, ValueFromPipelineByPropertyName=$True, ParameterSetName='CustomObject', Position=0)]
 		[ValidateNotNullOrEmpty()] [PSCustomObject[]] $CustomObject,
 		# Array of Hashtable key names or PSCustomObject property names to include, in display order.
 		# If not supplied then all Hashtable keys or all PSCustomObject properties will be displayed.
-		[Parameter(ValueFromPipelineByPropertyName=$true)] [AllowNull()] [string[]] $Columns = $null,
+		[Parameter(ValueFromPipelineByPropertyName=$True)] [AllowNull()] [string[]] $Columns = $Null,
 		# Array of custom table header strings in display order.
-		[Parameter(ValueFromPipelineByPropertyName=$true)] [AllowNull()] [string[]] $Headers = $null,
+		[Parameter(ValueFromPipelineByPropertyName=$True)] [AllowNull()] [string[]] $Headers = $Null,
 		# AutoFit table behavior.
-		[Parameter(ValueFromPipelineByPropertyName=$true)] [AllowNull()] [int] $AutoFit = -1,
+		[Parameter(ValueFromPipelineByPropertyName=$True)] [AllowNull()] [int] $AutoFit = -1,
 		# List view (no headers)
 		[Switch] $List,
 		# Grid lines
 		[Switch] $NoGridLines,
+		[Switch] $NoInternalGridLines,
 		# Built-in Word table formatting style constant
 		# Would recommend only $wdTableFormatContempory for normal usage (possibly $wdTableFormatList5 for List view)
-		[Parameter(ValueFromPipelineByPropertyName=$true)] [int] $Format = 0
+		[Parameter(ValueFromPipelineByPropertyName=$True)] [int] $Format = 0
 	)
 
 	Begin 
 	{
 		Write-Debug ("Using parameter set '{0}'" -f $PSCmdlet.ParameterSetName);
 		## Check if -Columns wasn't specified but -Headers were (saves some additional parameter sets!)
-		If(($Columns -eq $null) -and ($Headers -ne $null)) 
+		If(($Null -eq $Columns) -and ($Null -eq $Headers)) 
 		{
 			Write-Warning "No columns specified and therefore, specified headers will be ignored.";
-			$Columns = $null;
+			$Columns = $Null;
 		}
-		ElseIf(($Columns -ne $null) -and ($Headers -ne $null)) 
+		ElseIf(($Null -ne $Columns) -and ($Null -ne $Headers)) 
 		{
 			## Check if number of specified -Columns matches number of specified -Headers
 			If($Columns.Length -ne $Headers.Length) 
@@ -3893,13 +4036,13 @@ Function AddWordTable
 	Process
 	{
 		## Build the Word table data string to be converted to a range and then a table later.
-        [System.Text.StringBuilder] $WordRangeString = New-Object System.Text.StringBuilder;
+		[System.Text.StringBuilder] $WordRangeString = New-Object System.Text.StringBuilder;
 
 		Switch ($PSCmdlet.ParameterSetName) 
 		{
 			'CustomObject' 
 			{
-				If($Columns -eq $null) 
+				If($Null -eq $Columns) 
 				{
 					## Build the available columns from all availble PSCustomObject note properties
 					[string[]] $Columns = @();
@@ -3913,19 +4056,19 @@ Function AddWordTable
 				## Add the table headers from -Headers or -Columns (except when in -List(view)
 				If(-not $List) 
 				{
-					Write-Debug ("$(Get-Date): `t`tBuilding table headers");
-					If($Headers -ne $null) 
+					Write-Debug ("$(Get-Date -Format G): `t`tBuilding table headers");
+					If($Null -ne $Headers) 
 					{
-                        [ref] $null = $WordRangeString.AppendFormat("{0}`n", [string]::Join("`t", $Headers));
+                        [ref] $Null = $WordRangeString.AppendFormat("{0}`n", [string]::Join("`t", $Headers));
 					}
 					Else 
 					{ 
-                        [ref] $null = $WordRangeString.AppendFormat("{0}`n", [string]::Join("`t", $Columns));
+                        [ref] $Null = $WordRangeString.AppendFormat("{0}`n", [string]::Join("`t", $Columns));
 					}
 				}
 
 				## Iterate through each PSCustomObject
-				Write-Debug ("$(Get-Date): `t`tBuilding table rows");
+				Write-Debug ("$(Get-Date -Format G): `t`tBuilding table rows");
 				ForEach($Object in $CustomObject) 
 				{
 					$OrderedValues = @();
@@ -3935,14 +4078,14 @@ Function AddWordTable
 						$OrderedValues += $Object.$Column; 
 					}
 					## Use the ordered list to add each column in specified order
-                    [ref] $null = $WordRangeString.AppendFormat("{0}`n", [string]::Join("`t", $OrderedValues));
-				} ## end foreach
-				Write-Debug ("$(Get-Date): `t`t`tAdded '{0}' table rows" -f ($CustomObject.Count));
+					[ref] $Null = $WordRangeString.AppendFormat("{0}`n", [string]::Join("`t", $OrderedValues));
+				} ## end ForEach
+				Write-Debug ("$(Get-Date -Format G): `t`t`tAdded '{0}' table rows" -f ($CustomObject.Count));
 			} ## end CustomObject
 
 			Default 
 			{   ## Hashtable
-				If($Columns -eq $null) 
+				If($Null -eq $Columns) 
 				{
 					## Build the available columns from all available hashtable keys. Hopefully
 					## all Hashtables have the same keys (they should for a table).
@@ -3952,19 +4095,19 @@ Function AddWordTable
 				## Add the table headers from -Headers or -Columns (except when in -List(view)
 				If(-not $List) 
 				{
-					Write-Debug ("$(Get-Date): `t`tBuilding table headers");
-					If($Headers -ne $null) 
+					Write-Debug ("$(Get-Date -Format G): `t`tBuilding table headers");
+					If($Null -ne $Headers) 
 					{ 
-                        [ref] $null = $WordRangeString.AppendFormat("{0}`n", [string]::Join("`t", $Headers));
+						[ref] $Null = $WordRangeString.AppendFormat("{0}`n", [string]::Join("`t", $Headers));
 					}
 					Else 
 					{
-                        [ref] $null = $WordRangeString.AppendFormat("{0}`n", [string]::Join("`t", $Columns));
+						[ref] $Null = $WordRangeString.AppendFormat("{0}`n", [string]::Join("`t", $Columns));
 					}
 				}
                 
 				## Iterate through each Hashtable
-				Write-Debug ("$(Get-Date): `t`tBuilding table rows");
+				Write-Debug ("$(Get-Date -Format G): `t`tBuilding table rows");
 				ForEach($Hash in $Hashtable) 
 				{
 					$OrderedValues = @();
@@ -3974,15 +4117,15 @@ Function AddWordTable
 						$OrderedValues += $Hash.$Column; 
 					}
 					## Use the ordered list to add each column in specified order
-                    [ref] $null = $WordRangeString.AppendFormat("{0}`n", [string]::Join("`t", $OrderedValues));
-				} ## end foreach
+					[ref] $Null = $WordRangeString.AppendFormat("{0}`n", [string]::Join("`t", $OrderedValues));
+				} ## end ForEach
 
-				Write-Debug ("$(Get-Date): `t`t`tAdded '{0}' table rows" -f $Hashtable.Count);
+				Write-Debug ("$(Get-Date -Format G): `t`t`tAdded '{0}' table rows" -f $Hashtable.Count);
 			} ## end default
 		} ## end switch
 
 		## Create a MS Word range and set its text to our tab-delimited, concatenated string
-		Write-Debug ("$(Get-Date): `t`tBuilding table range");
+		Write-Debug ("$(Get-Date -Format G): `t`tBuilding table range");
 		$WordRange = $Script:Doc.Application.Selection.Range;
 		$WordRange.Text = $WordRangeString.ToString();
 
@@ -3993,38 +4136,38 @@ Function AddWordTable
 		If($Format -ge 0) 
 		{
 			$ConvertToTableArguments.Add("Format", $Format);
-			$ConvertToTableArguments.Add("ApplyBorders", $true);
-			$ConvertToTableArguments.Add("ApplyShading", $true);
-			$ConvertToTableArguments.Add("ApplyFont", $true);
-			$ConvertToTableArguments.Add("ApplyColor", $true);
+			$ConvertToTableArguments.Add("ApplyBorders", $True);
+			$ConvertToTableArguments.Add("ApplyShading", $True);
+			$ConvertToTableArguments.Add("ApplyFont", $True);
+			$ConvertToTableArguments.Add("ApplyColor", $True);
 			If(!$List) 
 			{ 
-				$ConvertToTableArguments.Add("ApplyHeadingRows", $true); 
+				$ConvertToTableArguments.Add("ApplyHeadingRows", $True); 
 			}
-			$ConvertToTableArguments.Add("ApplyLastRow", $true);
-			$ConvertToTableArguments.Add("ApplyFirstColumn", $true);
-			$ConvertToTableArguments.Add("ApplyLastColumn", $true);
+			$ConvertToTableArguments.Add("ApplyLastRow", $True);
+			$ConvertToTableArguments.Add("ApplyFirstColumn", $True);
+			$ConvertToTableArguments.Add("ApplyLastColumn", $True);
 		}
 
 		## Invoke ConvertToTable method - with named arguments - to convert Word range to a table
 		## See http://msdn.microsoft.com/en-us/library/office/aa171893(v=office.11).aspx
-		Write-Debug ("$(Get-Date): `t`tConverting range to table");
+		Write-Debug ("$(Get-Date -Format G): `t`tConverting range to table");
 		## Store the table reference just in case we need to set alternate row coloring
 		$WordTable = $WordRange.GetType().InvokeMember(
 			"ConvertToTable",                               # Method name
 			[System.Reflection.BindingFlags]::InvokeMethod, # Flags
-			$null,                                          # Binder
+			$Null,                                          # Binder
 			$WordRange,                                     # Target (self!)
 			([Object[]]($ConvertToTableArguments.Values)),  ## Named argument values
-			$null,                                          # Modifiers
-			$null,                                          # Culture
+			$Null,                                          # Modifiers
+			$Null,                                          # Culture
 			([String[]]($ConvertToTableArguments.Keys))     ## Named argument names
 		);
 
 		## Implement grid lines (will wipe out any existing formatting
 		If($Format -lt 0) 
 		{
-			Write-Debug ("$(Get-Date): `t`tSetting table format");
+			Write-Debug ("$(Get-Date -Format G): `t`tSetting table format");
 			$WordTable.Style = $Format;
 		}
 
@@ -4034,12 +4177,25 @@ Function AddWordTable
 			$WordTable.AutoFitBehavior($AutoFit); 
 		}
 
-		#the next line causes the heading row to flow across page breaks
-		$WordTable.Rows.First.Headingformat = $wdHeadingFormatTrue;
+		If(!$List)
+		{
+			#the next line causes the heading row to flow across page breaks
+			$WordTable.Rows.First.Headingformat = $wdHeadingFormatTrue;
+		}
 
 		If(!$NoGridLines) 
 		{
 			$WordTable.Borders.InsideLineStyle = $wdLineStyleSingle;
+			$WordTable.Borders.OutsideLineStyle = $wdLineStyleSingle;
+		}
+		If($NoGridLines) 
+		{
+			$WordTable.Borders.InsideLineStyle = $wdLineStyleNone;
+			$WordTable.Borders.OutsideLineStyle = $wdLineStyleNone;
+		}
+		If($NoInternalGridLines) 
+		{
+			$WordTable.Borders.InsideLineStyle = $wdLineStyleNone;
 			$WordTable.Borders.OutsideLineStyle = $wdLineStyleSingle;
 		}
 
@@ -4093,21 +4249,21 @@ Function SetWordCellFormat
 	[CmdletBinding(DefaultParameterSetName='Collection')]
 	Param (
 		# Word COM object cell collection reference
-		[Parameter(Mandatory=$true, ValueFromPipeline=$true, ParameterSetName='Collection', Position=0)] [ValidateNotNullOrEmpty()] $Collection,
+		[Parameter(Mandatory=$True, ValueFromPipeline=$True, ParameterSetName='Collection', Position=0)] [ValidateNotNullOrEmpty()] $Collection,
 		# Word COM object individual cell reference
-		[Parameter(Mandatory=$true, ParameterSetName='Cell', Position=0)] [ValidateNotNullOrEmpty()] $Cell,
+		[Parameter(Mandatory=$True, ParameterSetName='Cell', Position=0)] [ValidateNotNullOrEmpty()] $Cell,
 		# Hashtable of cell co-ordinates
-		[Parameter(Mandatory=$true, ParameterSetName='Hashtable', Position=0)] [ValidateNotNullOrEmpty()] [System.Collections.Hashtable[]] $Coordinates,
+		[Parameter(Mandatory=$True, ParameterSetName='Hashtable', Position=0)] [ValidateNotNullOrEmpty()] [System.Collections.Hashtable[]] $Coordinates,
 		# Word COM object table reference
-		[Parameter(Mandatory=$true, ParameterSetName='Hashtable', Position=1)] [ValidateNotNullOrEmpty()] $Table,
+		[Parameter(Mandatory=$True, ParameterSetName='Hashtable', Position=1)] [ValidateNotNullOrEmpty()] $Table,
 		# Font name
-		[Parameter()] [AllowNull()] [string] $Font = $null,
+		[Parameter()] [AllowNull()] [string] $Font = $Null,
 		# Font color
-		[Parameter()] [AllowNull()] $Color = $null,
+		[Parameter()] [AllowNull()] $Color = $Null,
 		# Font size
 		[Parameter()] [ValidateNotNullOrEmpty()] [int] $Size = 0,
 		# Cell background color
-		[Parameter()] [AllowNull()] [int]$BackgroundColor = $null,
+		[Parameter()] [AllowNull()] [int]$BackgroundColor = $Null,
 		# Force solid background color
 		[Switch] $Solid,
 		[Switch] $Bold,
@@ -4127,25 +4283,25 @@ Function SetWordCellFormat
 			'Collection' {
 				ForEach($Cell in $Collection) 
 				{
-					If($BackgroundColor -ne $null) { $Cell.Shading.BackgroundPatternColor = $BackgroundColor; }
-					If($Bold) { $Cell.Range.Font.Bold = $true; }
-					If($Italic) { $Cell.Range.Font.Italic = $true; }
+					If($Null -ne $BackgroundColor) { $Cell.Shading.BackgroundPatternColor = $BackgroundColor; }
+					If($Bold) { $Cell.Range.Font.Bold = $True; }
+					If($Italic) { $Cell.Range.Font.Italic = $True; }
 					If($Underline) { $Cell.Range.Font.Underline = 1; }
-					If($Font -ne $null) { $Cell.Range.Font.Name = $Font; }
-					If($Color -ne $null) { $Cell.Range.Font.Color = $Color; }
+					If($Null -ne $Font) { $Cell.Range.Font.Name = $Font; }
+					If($Null -ne $Color) { $Cell.Range.Font.Color = $Color; }
 					If($Size -ne 0) { $Cell.Range.Font.Size = $Size; }
 					If($Solid) { $Cell.Shading.Texture = 0; } ## wdTextureNone
-				} # end foreach
+				} # end ForEach
 			} # end Collection
 			'Cell' 
 			{
-				If($Bold) { $Cell.Range.Font.Bold = $true; }
-				If($Italic) { $Cell.Range.Font.Italic = $true; }
+				If($Bold) { $Cell.Range.Font.Bold = $True; }
+				If($Italic) { $Cell.Range.Font.Italic = $True; }
 				If($Underline) { $Cell.Range.Font.Underline = 1; }
-				If($Font -ne $null) { $Cell.Range.Font.Name = $Font; }
-				If($Color -ne $null) { $Cell.Range.Font.Color = $Color; }
+				If($Null -ne $Font) { $Cell.Range.Font.Name = $Font; }
+				If($Null -ne $Color) { $Cell.Range.Font.Color = $Color; }
 				If($Size -ne 0) { $Cell.Range.Font.Size = $Size; }
-				If($BackgroundColor -ne $null) { $Cell.Shading.BackgroundPatternColor = $BackgroundColor; }
+				If($Null -ne $BackgroundColor) { $Cell.Shading.BackgroundPatternColor = $BackgroundColor; }
 				If($Solid) { $Cell.Shading.Texture = 0; } ## wdTextureNone
 			} # end Cell
 			'Hashtable' 
@@ -4153,13 +4309,13 @@ Function SetWordCellFormat
 				ForEach($Coordinate in $Coordinates) 
 				{
 					$Cell = $Table.Cell($Coordinate.Row, $Coordinate.Column);
-					If($Bold) { $Cell.Range.Font.Bold = $true; }
-					If($Italic) { $Cell.Range.Font.Italic = $true; }
+					If($Bold) { $Cell.Range.Font.Bold = $True; }
+					If($Italic) { $Cell.Range.Font.Italic = $True; }
 					If($Underline) { $Cell.Range.Font.Underline = 1; }
-					If($Font -ne $null) { $Cell.Range.Font.Name = $Font; }
-					If($Color -ne $null) { $Cell.Range.Font.Color = $Color; }
+					If($Null -ne $Font) { $Cell.Range.Font.Name = $Font; }
+					If($Null -ne $Color) { $Cell.Range.Font.Color = $Color; }
 					If($Size -ne 0) { $Cell.Range.Font.Size = $Size; }
-					If($BackgroundColor -ne $null) { $Cell.Shading.BackgroundPatternColor = $BackgroundColor; }
+					If($Null -ne $BackgroundColor) { $Cell.Shading.BackgroundPatternColor = $BackgroundColor; }
 					If($Solid) { $Cell.Shading.Texture = 0; } ## wdTextureNone
 				}
 			} # end Hashtable
@@ -4272,11 +4428,11 @@ Function ShowScriptOptions
 Function validStateProp( [object] $object, [string] $topLevel, [string] $secondLevel )
 {
 	#function created 8-jan-2014 by Michael B. Smith
-	if( $object )
+	If( $object )
 	{
-		If( ( gm -Name $topLevel -InputObject $object ) )
+		If((Get-Member -Name $topLevel -InputObject $object))
 		{
-			If( ( gm -Name $secondLevel -InputObject $object.$topLevel ) )
+			If((Get-Member -Name $secondLevel -InputObject $object.$topLevel))
 			{
 				Return $True
 			}
@@ -4293,7 +4449,7 @@ Function SetupWord
 	Write-Verbose "$(Get-Date): Create Word comObject.  Ignore the next message."
 	$Script:Word = New-Object -comobject "Word.Application" -EA 0 4>$Null
 	
-	If(!$? -or $Script:Word -eq $Null)
+	If(!$? -or $Null -eq $Script:Word)
 	{
 		Write-Warning "The Word object could not be created.  You may need to repair your Word installation."
 		$ErrorActionPreference = $SaveEAPreference
@@ -4555,20 +4711,20 @@ Function SetupWord
 
 	$Script:Word.Templates.LoadBuildingBlocks()
 	#word 2010/2013
-	$BuildingBlocksCollection = $Script:Word.Templates | Where {$_.name -eq "Built-In Building Blocks.dotx"}
+	$BuildingBlocksCollection = $Script:Word.Templates | Where-Object{$_.name -eq "Built-In Building Blocks.dotx"}
 
 	Write-Verbose "$(Get-Date): Attempt to load cover page $($CoverPage)"
 	$part = $Null
 
 	$BuildingBlocksCollection | 
-	ForEach{
+	ForEach-Object {
 		If ($_.BuildingBlockEntries.Item($CoverPage).Name -eq $CoverPage) 
 		{
 			$BuildingBlocks = $_
 		}
 	}        
 
-	If($BuildingBlocks -ne $Null)
+	If($Null -ne $BuildingBlocks)
 	{
 		$BuildingBlocksExist = $True
 
@@ -4582,7 +4738,7 @@ Function SetupWord
 			$part = $Null
 		}
 
-		If($part -ne $Null)
+		If($Null -ne $part)
 		{
 			$Script:CoverPagesExist = $True
 		}
@@ -4597,7 +4753,7 @@ Function SetupWord
 
 	Write-Verbose "$(Get-Date): Create empty word doc"
 	$Script:Doc = $Script:Word.Documents.Add()
-	If($Script:Doc -eq $Null)
+	If($Null -ne $Script:Doc)
 	{
 		Write-Verbose "$(Get-Date): "
 		$ErrorActionPreference = $SaveEAPreference
@@ -4614,7 +4770,7 @@ Function SetupWord
 	}
 
 	$Script:Selection = $Script:Word.Selection
-	If($Script:Selection -eq $Null)
+	If($Null -eq $Script:Selection)
 	{
 		Write-Verbose "$(Get-Date): "
 		$ErrorActionPreference = $SaveEAPreference
@@ -4653,7 +4809,7 @@ Function SetupWord
 		#table of contents
 		Write-Verbose "$(Get-Date): Table of Contents - $($myHash.Word_TableOfContents)"
 		$toc = $BuildingBlocks.BuildingBlockEntries.Item($myHash.Word_TableOfContents)
-		If($toc -eq $Null)
+		If($Null -eq $toc)
 		{
 			Write-Verbose "$(Get-Date): "
 			Write-Verbose "$(Get-Date): Table of Content - $($myHash.Word_TableOfContents) could not be retrieved."
@@ -4710,7 +4866,7 @@ Function UpdateDocumentProperties
 	{
 		If($Script:CoverPagesExist)
 		{
-			Write-Verbose "$(Get-Date): Set Cover Page Properties"
+			Write-Verbose "$(Get-Date -Format G): Set Cover Page Properties"
 			#8-Jun-2017 put these 4 items in alpha order
             Set-DocumentProperty -Document $Script:Doc -DocProperty Author -Value $UserName
             Set-DocumentProperty -Document $Script:Doc -DocProperty Company -Value $Script:CoName
@@ -4718,10 +4874,10 @@ Function UpdateDocumentProperties
             Set-DocumentProperty -Document $Script:Doc -DocProperty Title -Value $Script:title
 
 			#Get the Coverpage XML part
-			$cp = $Script:Doc.CustomXMLParts | Where {$_.NamespaceURI -match "coverPageProps$"}
+			$cp = $Script:Doc.CustomXMLParts | Where-Object{$_.NamespaceURI -match "coverPageProps$"}
 
 			#get the abstract XML part
-			$ab = $cp.documentelement.ChildNodes | Where {$_.basename -eq "Abstract"}
+			$ab = $cp.documentelement.ChildNodes | Where-Object{$_.basename -eq "Abstract"}
 			#set the text
 			If([String]::IsNullOrEmpty($Script:CoName))
 			{
@@ -4734,35 +4890,35 @@ Function UpdateDocumentProperties
 			$ab.Text = $abstract
 
 			#added 8-Jun-2017
-			$ab = $cp.documentelement.ChildNodes | Where {$_.basename -eq "CompanyAddress"}
+			$ab = $cp.documentelement.ChildNodes | Where-Object{$_.basename -eq "CompanyAddress"}
 			#set the text
 			[string]$abstract = $CompanyAddress
 			$ab.Text = $abstract
 
 			#added 8-Jun-2017
-			$ab = $cp.documentelement.ChildNodes | Where {$_.basename -eq "CompanyEmail"}
+			$ab = $cp.documentelement.ChildNodes | Where-Object{$_.basename -eq "CompanyEmail"}
 			#set the text
 			[string]$abstract = $CompanyEmail
 			$ab.Text = $abstract
 
 			#added 8-Jun-2017
-			$ab = $cp.documentelement.ChildNodes | Where {$_.basename -eq "CompanyFax"}
+			$ab = $cp.documentelement.ChildNodes | Where-Object{$_.basename -eq "CompanyFax"}
 			#set the text
 			[string]$abstract = $CompanyFax
 			$ab.Text = $abstract
 
 			#added 8-Jun-2017
-			$ab = $cp.documentelement.ChildNodes | Where {$_.basename -eq "CompanyPhone"}
+			$ab = $cp.documentelement.ChildNodes | Where-Object{$_.basename -eq "CompanyPhone"}
 			#set the text
 			[string]$abstract = $CompanyPhone
 			$ab.Text = $abstract
 
-			$ab = $cp.documentelement.ChildNodes | Where {$_.basename -eq "PublishDate"}
+			$ab = $cp.documentelement.ChildNodes | Where-Object{$_.basename -eq "PublishDate"}
 			#set the text
 			[string]$abstract = (Get-Date -Format d).ToString()
 			$ab.Text = $abstract
 
-			Write-Verbose "$(Get-Date): Update the Table of Contents"
+			Write-Verbose "$(Get-Date -Format G): Update the Table of Contents"
 			#update the Table of Contents
 			$Script:Doc.TablesOfContents.item(1).Update()
 			$cp = $Null
@@ -4839,15 +4995,10 @@ Function SaveandCloseDocumentandShutdownWord
 		}
 	}
 
-	Write-Verbose "$(Get-Date): Closing Word"
+	Write-Verbose "$(Get-Date -Format G): Closing Word"
 	$Script:Doc.Close()
 	$Script:Word.Quit()
-	If($PDF)
-	{
-		Write-Verbose "$(Get-Date): Deleting $($Script:FileName1) since only $($Script:FileName2) is needed"
-		Remove-Item $Script:FileName1 4>$Null
-	}
-	Write-Verbose "$(Get-Date): System Cleanup"
+	Write-Verbose "$(Get-Date -Format G): System Cleanup"
 	[System.Runtime.Interopservices.Marshal]::ReleaseComObject($Script:Word) | Out-Null
 	If(Test-Path variable:global:word)
 	{
@@ -4856,6 +5007,19 @@ Function SaveandCloseDocumentandShutdownWord
 	$SaveFormat = $Null
 	[gc]::collect() 
 	[gc]::WaitForPendingFinalizers()
+	
+	#is the winword Process still running? kill it
+
+	#find out our session (usually "1" except on TS/RDC or Citrix)
+	$SessionID = (Get-Process -PID $PID).SessionId
+
+	#Find out if winword running in our session
+	$wordprocess = ((Get-Process 'WinWord' -ea 0) | Where-Object {$_.SessionId -eq $SessionID}) | Select-Object -Property Id 
+	If( $wordprocess -and $wordprocess.Id -gt 0)
+	{
+		Write-Verbose "$(Get-Date -Format G): WinWord Process is still running. Attempting to stop WinWord Process # $($wordprocess.Id)"
+		Stop-Process $wordprocess.Id -EA 0
+	}
 }
 
 Function SetFileName1andFileName2
@@ -4960,7 +5124,7 @@ If($Software)
 Write-Verbose "$(Get-Date): Getting initial Farm data"
 $farm = Get-XAFarm -EA 0
 
-If($? -and $Farm -ne $Null)
+If($? -and $Null -ne $Farm)
 {
 	Write-Verbose "$(Get-Date): Verify farm version"
 	#first check to make sure this is a XenApp 6 farm
@@ -5001,7 +5165,7 @@ If(!$Summary -and ($Section -eq "All" -or $Section -eq "ConfigLog"))
 	[bool]$ConfigLog = $False
 	$ConfigurationLogging = Get-XAConfigurationLog -EA 0
 
-	If($? -and $ConfigurationLogging -ne $Null)
+	If($? -and $Null -ne $ConfigurationLogging)
 	{
 		$selection.InsertNewPage()
 		WriteWordLine 1 0 "Configuration Logging"
@@ -5048,9 +5212,9 @@ If($Section -eq "All" -or $Section -eq "Admins")
 	[int]$TotalAdmins = 0
 
 	Write-Verbose "$(Get-Date): `tRetrieving Administrators"
-	$Administrators = Get-XAAdministrator -EA 0 | Sort AdministratorName
+	$Administrators = Get-XAAdministrator -EA 0 | Sort-Object AdministratorName
 
-	If($? -and $Administrators -ne $Null)
+	If($? -and $Null -ne $Administrators)
 	{
 		$selection.InsertNewPage()
 		WriteWordLine 1 0 "Administrators:"
@@ -5179,14 +5343,14 @@ If($Section -eq "All" -or $Section -eq "Apps")
 	Write-Verbose "$(Get-Date): `tRetrieving Applications"
 	If($Summary)
 	{
-		$Applications = Get-XAApplication -EA 0 | Sort DisplayName
+		$Applications = Get-XAApplication -EA 0 | Sort-Object DisplayName
 	}
 	Else
 	{
-		$Applications = Get-XAApplication -EA 0 | Sort FolderPath, DisplayName
+		$Applications = Get-XAApplication -EA 0 | Sort-Object FolderPath, DisplayName
 	}
 
-	If($? -and $Applications -ne $Null)
+	If($? -and $Null -ne $Applications)
 	{
 		$selection.InsertNewPage()
 		WriteWordLine 1 0 "Applications:"
@@ -5236,7 +5400,7 @@ If($Section -eq "All" -or $Section -eq "Apps")
 				
 				[bool]$AppServerInfoResults = $False
 				$AppServerInfo = Get-XAApplicationReport -BrowserName $Application.BrowserName -EA 0
-				If($? -and $AppServerInfo -ne $Null)
+				If($? -and $Null -ne $AppServerInfo)
 				{
 					$AppServerInfoResults = $True
 				}
@@ -5379,14 +5543,14 @@ If($Section -eq "All" -or $Section -eq "Apps")
 						If(![String]::IsNullOrEmpty($AppServerInfo.ServerNames))
 						{
 							WriteWordLine 0 1 "Servers:"
-							$TempArray = $AppServerInfo.ServerNames | Sort
+							$TempArray = $AppServerInfo.ServerNames | Sort-Object
 							BuildTableForServerOrWG $TempArray "Server"
 							$TempArray = $Null
 						}
 						If(![String]::IsNullOrEmpty($AppServerInfo.WorkerGroupNames))
 						{
 							WriteWordLine 0 1 "Worker Groups:"
-							$TempArray = $AppServerInfo.WorkerGroupNames | Sort
+							$TempArray = $AppServerInfo.WorkerGroupNames | Sort-Object
 							BuildTableForServerOrWG $TempArray "Server"
 							$TempArray = $Null
 						}
@@ -5700,7 +5864,7 @@ If($Section -eq "All" -or $Section -eq "Apps")
 			}
 		}
 	}
-	ElseIf($Applications -eq $Null)
+	ElseIf($Null -eq $Applications)
 	{
 		Write-Verbose "$(Get-Date): There are no Applications published"
 	}
@@ -5733,7 +5897,7 @@ If(!$Summary -and ($Section -eq "All" -or $Section -eq "ConfigLog"))
 			$ConnectionString = Get-Content "$($pwd.path)\XA6ConfigLog.udl" 4>$Null| select-object -last 1
 			$ConfigLogReport = Get-CtxConfigurationLogReport -connectionstring $ConnectionString -TimePeriodFrom $StartDate -TimePeriodTo $EndDate -EA 0 4>$Null
 
-			If($? -and $ConfigLogReport -ne $Null)
+			If($? -and $Null -ne $ConfigLogReport)
 			{
 				Write-Verbose "$(Get-Date): `tProcessing $($ConfigLogReport.Count) history items"
 				$selection.InsertNewPage()
@@ -5799,7 +5963,7 @@ If(!$Summary -and ($Section -eq "All" -or $Section -eq "ConfigLog"))
 
 				FindWordDocumentEnd
 			} 
-			ElseIf($? -and $ConfigLogReport -eq $Null)
+			ElseIf($? -and $Null -eq $ConfigLogReport)
 			{
 				Write-Verbose "$(Get-Date): There was no configuration logging data returned"
 				WriteWordLine 0 0 "There was no configuration logging data returned"
@@ -5829,9 +5993,9 @@ If($Section -eq "All" -or $Section -eq "LBPolicies")
 	[int]$TotalLBPolicies = 0
 
 	Write-Verbose "$(Get-Date): `tRetrieving Load Balancing Policies"
-	$LoadBalancingPolicies = Get-XALoadBalancingPolicy -EA 0 | Sort PolicyName
+	$LoadBalancingPolicies = Get-XALoadBalancingPolicy -EA 0 | Sort-Object PolicyName
 
-	If($? -and $LoadBalancingPolicies -ne $Null)
+	If($? -and $Null -ne $LoadBalancingPolicies)
 	{
 		$selection.InsertNewPage()
 		WriteWordLine 1 0 "Load Balancing Policies:"
@@ -6089,7 +6253,7 @@ If($Section -eq "All" -or $Section -eq "LBPolicies")
 			}
 		}
 	}
-	ElseIf($LoadBalancingPolicies -eq $Null)
+	ElseIf($Null -eq $LoadBalancingPolicies)
 	{
 		Write-Verbose "$(Get-Date): There are no Load balancing policies created"
 	}
@@ -6110,9 +6274,9 @@ If($Section -eq "All" -or $Section -eq "LoadEvals")
 	[int]$TotalLoadEvaluators = 0
 
 	Write-Verbose "$(Get-Date): `tRetrieving Load Evaluators"
-	$LoadEvaluators = Get-XALoadEvaluator -EA 0 | Sort LoadEvaluatorName
+	$LoadEvaluators = Get-XALoadEvaluator -EA 0 | Sort-Object LoadEvaluatorName
 
-	If($? -and $LoadEvaluators -ne $Null)
+	If($? -and $Null -ne $LoadEvaluators)
 	{
 		$selection.InsertNewPage()
 		WriteWordLine 1 0 "Load Evaluators:"
@@ -6279,14 +6443,14 @@ If($Section -eq "All" -or $Section -eq "Servers")
 	Write-Verbose "$(Get-Date): `tRetrieving Servers"
 	If($Summary)
 	{
-		$servers = Get-XAServer -EA 0 | Sort ServerName
+		$servers = Get-XAServer -EA 0 | Sort-Object ServerName
 	}
 	Else
 	{
-		$servers = Get-XAServer -EA 0 | Sort FolderPath, ServerName
+		$servers = Get-XAServer -EA 0 | Sort-Object FolderPath, ServerName
 	}
 
-	If($? -and $Servers -ne $Null)
+	If($? -and $Null -ne $Servers)
 	{
 		$selection.InsertNewPage()
 		WriteWordLine 1 0 "Servers:"
@@ -6410,8 +6574,8 @@ If($Section -eq "All" -or $Section -eq "Servers")
 				}
 
 				#applications published to server
-				$Applications = Get-XAApplication -ServerName $server.ServerName -EA 0 | Sort FolderPath, DisplayName
-				If($? -and $Applications -ne $Null)
+				$Applications = Get-XAApplication -ServerName $server.ServerName -EA 0 | Sort-Object FolderPath, DisplayName
+				If($? -and $Null -ne $Applications)
 				{
 					WriteWordLine 0 1 "Published applications:"
 					Write-Verbose "$(Get-Date): `t`tProcessing published applications for server $($server.ServerName)"
@@ -6475,7 +6639,7 @@ If($Section -eq "All" -or $Section -eq "Servers")
 					$regkey1=$reg.OpenSubKey($UninstallKey1) 
 
 					#Retrieve an array of string that contain all the subkey names
-					If($regkey1 -ne $Null)
+					If($Null -ne $regkey1)
 					{
 						$subkeys1=$regkey1.GetSubKeyNames() 
 
@@ -6496,7 +6660,7 @@ If($Section -eq "All" -or $Section -eq "Servers")
 
 					$UninstallKey2="SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall" 
 					$regkey2=$reg.OpenSubKey($UninstallKey2)
-					If($regkey2 -ne $Null)
+					If($Null -ne $regkey2)
 					{
 						$subkeys2=$regkey2.GetSubKeyNames()
 
@@ -6514,7 +6678,7 @@ If($Section -eq "All" -or $Section -eq "Servers")
 						}
 					}
 
-					$InstalledApps = $InstalledApps | Sort DisplayName
+					$InstalledApps = $InstalledApps | Sort-Object DisplayName
 
 					$tmp1 = SWExclusions
 					If($Tmp1 -ne "")
@@ -6526,7 +6690,7 @@ If($Section -eq "All" -or $Section -eq "Servers")
 					{
 						$tempapps = $InstalledApps
 					}
-					$JustApps = $TempApps | Select DisplayName, DisplayVersion | Sort DisplayName -unique
+					$JustApps = $TempApps | Select-Object DisplayName, DisplayVersion | Sort-Object DisplayName -unique
 
 					WriteWordLine 0 1 "Installed applications:"
 					Write-Verbose "$(Get-Date): `t`tProcessing installed applications for server $($server.ServerName)"
@@ -6572,7 +6736,18 @@ If($Section -eq "All" -or $Section -eq "Servers")
 						#Replaced with a single call to retrieve services via WMI. The repeated
 						## "Get-WMIObject Win32_Service -Filter" calls were the major delays in the script.
 						## If we need to retrieve the StartUp type might as well just use WMI.
-						$Services = Get-WMIObject Win32_Service -ComputerName $server.ServerName -EA 0 | Where {$_.DisplayName -like "*Citrix*"} | Sort DisplayName
+						If($server.ServerName -eq $env:computername)
+						{
+							$Services = Get-CIMInstance Win32_Service -EA 0 -Verbose:$False | `
+							Where-Object {$_.DisplayName -like "*Citrix*"} | `
+							Sort-Object DisplayName
+						}
+						Else
+						{
+							$Services = Get-CIMInstance Win32_Service -CIMSession $server.ServerName -EA 0 -Verbose:$False | `
+							Where-Object {$_.DisplayName -like "*Citrix*"} | `
+							Sort-Object DisplayName
+						}
 					}
 					
 					Catch
@@ -6581,7 +6756,7 @@ If($Section -eq "All" -or $Section -eq "Servers")
 					}
 
 					WriteWordLine 0 1 "Citrix Services" -NoNewLine
-					If($? -and $Services -ne $Null)
+					If($? -and $Null -ne $Services)
 					{
 						If($Services -is [array])
 						{
@@ -6668,7 +6843,9 @@ If($Section -eq "All" -or $Section -eq "Servers")
 					Write-Verbose "$(Get-Date): `t`tGet list of Citrix hotfixes installed"
 					Try
 					{
-						$hotfixes = (Get-XAServerHotfix -ServerName $server.ServerName -EA 0 | Where {$_.Valid -eq $True}) | Sort HotfixName
+						$hotfixes = (Get-XAServerHotfix -ServerName $server.ServerName -EA 0 | `
+						Where-Object {$_.Valid -eq $True}) | `
+						Sort-Object HotfixName
 					}
 					
 					Catch
@@ -6676,7 +6853,7 @@ If($Section -eq "All" -or $Section -eq "Servers")
 						$hotfixes = $Null
 					}
 
-					If($? -and $hotfixes -ne $Null)
+					If($? -and $Null -ne $hotfixes)
 					{
 						[int]$Rows = 1
 						$Single_Row = (Get-Member -Type Property -Name Length -InputObject $hotfixes -EA 0) -eq $Null
@@ -6831,7 +7008,9 @@ If($Section -eq "All" -or $Section -eq "Servers")
 						Try
 						{
 							$results = Get-HotFix -computername $Server.ServerName 
-							$MSInstalledHotfixes = $results | select-object -Expand HotFixID | Sort HotFixID
+							$MSInstalledHotfixes = $results | `
+							Select-Object -Expand HotFixID | `
+							Sort-Object HotFixID
 							$results = $Null
 						}
 						
@@ -6993,9 +7172,9 @@ If($Section -eq "All" -or $Section -eq "WGs")
 	[int]$TotalWGs = 0
 
 	Write-Verbose "$(Get-Date): `tRetrieving Worker Groups"
-	$WorkerGroups = Get-XAWorkerGroup -EA 0 | Sort WorkerGroupName
+	$WorkerGroups = Get-XAWorkerGroup -EA 0 | Sort-Object WorkerGroupName
 
-	If($? -and $WorkerGroups -ne $Null)
+	If($? -and $Null -ne $WorkerGroups)
 	{
 		$selection.InsertNewPage()
 		WriteWordLine 1 0 "Worker Groups:"
@@ -7016,7 +7195,7 @@ If($Section -eq "All" -or $Section -eq "WGs")
 					WriteWordLine 0 1 "Farm Servers:"
 					Write-Verbose "$(Get-Date): `t`tProcessing Worker Group by Farm Servers"
 					Write-Verbose "$(Get-Date): `t`tCreate Word Table for Worker Group by Farm Server"
-					$TempArray = $WorkerGroup.ServerNames | Sort
+					$TempArray = $WorkerGroup.ServerNames | Sort-Object
 					BuildTableForServerOrWG $TempArray "Server"
 					$TempArray = $Null
 				}
@@ -7026,7 +7205,7 @@ If($Section -eq "All" -or $Section -eq "WGs")
 					WriteWordLine 0 1 "Server Group Accounts:"
 					Write-Verbose "$(Get-Date): `t`tProcessing Worker Group by Server Groups"
 					Write-Verbose "$(Get-Date): `t`tCreate Word Table for Worker Group by Server Groups"
-					$TempArray = $WorkerGroup.ServerGroups | Sort
+					$TempArray = $WorkerGroup.ServerGroups | Sort-Object
 					BuildTableForServerOrWG $TempArray "Security Group"
 					$TempArray = $Null
 				}
@@ -7036,13 +7215,13 @@ If($Section -eq "All" -or $Section -eq "WGs")
 					WriteWordLine 0 1 "Organizational Units:"
 					Write-Verbose "$(Get-Date): `t`tProcessing Worker Group by OUs"
 					Write-Verbose "$(Get-Date): `t`tCreate Word Table for Worker Group by OUs"
-					$TempArray = $WorkerGroup.OUs | Sort {$_.Length}
+					$TempArray = $WorkerGroup.OUs | Sort-Object {$_.Length}
 					BuildTableForServerOrWG $TempArray "OU"
 					$TempArray = $Null
 				}
 				#applications published to worker group
-				$Applications = Get-XAApplication -WorkerGroup $WorkerGroup.WorkerGroupName -EA 0 | Sort FolderPath, DisplayName
-				If($? -and $Applications -ne $Null)
+				$Applications = Get-XAApplication -WorkerGroup $WorkerGroup.WorkerGroupName -EA 0 | Sort-Object FolderPath, DisplayName
+				If($? -and $Null -ne $Applications)
 				{
 					WriteWordLine 0 0 ""
 					WriteWordLine 0 1 "Published applications:"
@@ -7093,7 +7272,7 @@ If($Section -eq "All" -or $Section -eq "WGs")
 			}
 		}
 	}
-	ElseIf($WorkerGroups -eq $Null)
+	ElseIf($Null -eq $WorkerGroups)
 	{
 
 		Write-Verbose "$(Get-Date): There are no Worker Groups created"
@@ -7115,8 +7294,8 @@ If($Section -eq "All" -or $Section -eq "Zones")
 	[int]$TotalZones = 0
 
 	Write-Verbose "$(Get-Date): `tRetrieving Zones"
-	$Zones = Get-XAZone -EA 0 | Sort ZoneName
-	If($? -and $Zones -ne $Null)
+	$Zones = Get-XAZone -EA 0 | Sort-Object ZoneName
+	If($? -and $Null -ne $Zones)
 	{
 		$selection.InsertNewPage()
 		WriteWordLine 1 0 "Zones:"
@@ -7128,8 +7307,8 @@ If($Section -eq "All" -or $Section -eq "Zones")
 			{
 				WriteWordLine 2 0 $Zone.ZoneName
 				WriteWordLine 0 1 "Current Data Collector: " $Zone.DataCollector
-				$Servers = Get-XAServer -ZoneName $Zone.ZoneName -EA 0 | Sort ElectionPreference, ServerName
-				If($? -and $Servers -ne $Null)
+				$Servers = Get-XAServer -ZoneName $Zone.ZoneName -EA 0 | Sort-Object ElectionPreference, ServerName
+				If($? -and $Null -ne $Servers)
 				{		
 					WriteWordLine 0 1 "Servers in Zone"
 			
@@ -7210,7 +7389,7 @@ If($Section -eq "All" -or $Section -eq "Policies")
 		{
 			Write-Verbose "$(Get-Date): There are $($CtxGPOArray.Count) Citrix AD based policies to process"
 
-			$CtxGPOArray = $CtxGPOArray | Sort
+			$CtxGPOArray = $CtxGPOArray | Sort-Object
 			
 			ForEach($CtxGPO in $CtxGPOArray)
 			{
@@ -7239,7 +7418,7 @@ If($Section -eq "All" -or $Section -eq "Policies")
 				If($Global:TotalADPoliciesNotProcessed -gt 0)
 				{
 					Write-Verbose "$(Get-Date): Processing list of Citrix AD Policies not processed"
-					$ADPoliciesNotProcessed = $ADPoliciesNotProcessed | Sort -unique
+					$ADPoliciesNotProcessed = $ADPoliciesNotProcessed | Sort-Object -unique
 					WriteWordLine 0 0 ""
 					WriteWordLine 2 0 "Active Directory Citrix policies that could not be processed:"
 					ForEach($Policy in $ADPoliciesNotProcessed)

--- a/XA6_Inventory_V43_ReadMe.rtf
+++ b/XA6_Inventory_V43_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -48,48 +48,45 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \s18\ql \li720\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin720\itap0\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 
 \sbasedon0 \snext18 \sqformat \spriority34 \styrsid11018755 List Paragraph;}{\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext19 \sqformat \spriority1 \styrsid685683 No Spacing;}{\*\cs20 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpat0\chcbpat21 
-\sbasedon10 \ssemihidden \sunhideused \styrsid7758767 Unresolved Mention;}}{\*\listtable{\list\listtemplateid67698717{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
-\'02\'00);}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li360\lin360 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'01);}{\levelnumbers\'01;}\rtlch\fcs1 
-\af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc2\levelnfcn2\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'02);}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 
-\fi-360\li1080\lin1080 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'03(\'03);}{\levelnumbers\'02;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel
-\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'03(\'04);}{\levelnumbers\'02;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li1800\lin1800 }{\listlevel\levelnfc2\levelnfcn2\leveljc0\leveljcn0
-\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'03(\'05);}{\levelnumbers\'02;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0
-\levelindent0{\leveltext\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2520\lin2520 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
-\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc2\levelnfcn2\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'08.;}{\levelnumbers\'01;}
-\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3240\lin3240 }{\listname ;}\listid606930752}{\list\listtemplateid1549820148\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li6480\lin6480 }{\listname ;}\listid1011838512}{\list\listtemplateid-1580037124\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
-\levelfollow0\levelstartat0\levelspace360\levelindent0{\leveltext\leveltemplateid105799672\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
-\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
-\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0
-\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0
-{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid1608537752}{\list\listtemplateid67698717{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
-\'02\'00);}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li360\lin360 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'01);}{\levelnumbers\'01;}\rtlch\fcs1 
-\af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc2\levelnfcn2\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'02);}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 
-\fi-360\li1080\lin1080 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'03(\'03);}{\levelnumbers\'02;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel
-\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'03(\'04);}{\levelnumbers\'02;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li1800\lin1800 }{\listlevel\levelnfc2\levelnfcn2\leveljc0\leveljcn0
-\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'03(\'05);}{\levelnumbers\'02;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0
-\levelindent0{\leveltext\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2520\lin2520 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
-\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc2\levelnfcn2\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'08.;}{\levelnumbers\'01;}
-\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3240\lin3240 }{\listname ;}\listid1671323803}}{\*\listoverridetable{\listoverride\listid1608537752\listoverridecount0\ls1}{\listoverride\listid1011838512\listoverridecount0\ls2}
-{\listoverride\listid606930752\listoverridecount0\ls3}{\listoverride\listid1671323803\listoverridecount0\ls4}}{\*\rsidtbl \rsid685683\rsid1788631\rsid3830441\rsid5119476\rsid7758767\rsid9533655\rsid9919316\rsid11018755\rsid11894281\rsid12019155
-\rsid12152570\rsid12204691\rsid12391750\rsid14053399}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min27}
-{\revtim\yr2020\mo5\dy9\hr11\min18}{\version11}{\edmins37}{\nofpages13}{\nofwords3867}{\nofchars22046}{\nofcharsws25862}{\vern127}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
-\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\sbasedon10 \ssemihidden \sunhideused \styrsid7758767 Unresolved Mention;}}{\*\listtable{\list\listtemplateid-1{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'00);}{\levelnumbers
+\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li360\lin360 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'01);}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li720\lin720 }
+{\listlevel\levelnfc2\levelnfcn2\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'02);}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1080\lin1080 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'03(\'03);}{\levelnumbers\'02;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0
+{\leveltext\'03(\'04);}{\levelnumbers\'02;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1800\lin1800 }{\listlevel\levelnfc2\levelnfcn2\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'03(\'05);}{\levelnumbers\'02;}\rtlch\fcs1 
+\af0 \ltrch\fcs0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2520\lin2520 }{\listlevel
+\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc2\levelnfcn2\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3240\lin3240 }{\listname ;}\listid606930752}{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\levelspace0\levelindent0
+{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid1011838512}{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0
+\levelspace360\levelindent0{\leveltext\leveltemplateid105799672\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0
+\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689
+\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 
+\fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel
+\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0
+\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1608537752}{\list\listtemplateid-1{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'00);}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li360\lin360 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0
+{\leveltext\'02\'01);}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li720\lin720 }{\listlevel\levelnfc2\levelnfcn2\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'02);}{\levelnumbers\'01;}\rtlch\fcs1 \af0 
+\ltrch\fcs0 \fi-360\li1080\lin1080 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'03(\'03);}{\levelnumbers\'02;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel
+\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'03(\'04);}{\levelnumbers\'02;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1800\lin1800 }{\listlevel\levelnfc2\levelnfcn2\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\levelspace0\levelindent0{\leveltext\'03(\'05);}{\levelnumbers\'02;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
+\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2520\lin2520 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 
+\ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc2\levelnfcn2\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3240\lin3240 }{\listname 
+;}\listid1671323803}}{\*\listoverridetable{\listoverride\listid1608537752\listoverridecount0\ls1}{\listoverride\listid1011838512\listoverridecount0\ls2}{\listoverride\listid606930752\listoverridecount0\ls3}{\listoverride\listid1671323803
+\listoverridecount0\ls4}}{\*\rsidtbl \rsid685683\rsid1788631\rsid3830441\rsid5119476\rsid7758767\rsid9533655\rsid9919316\rsid11018755\rsid11631936\rsid11894281\rsid12019155\rsid12152570\rsid12204691\rsid12391750\rsid13662517\rsid14053399}{\mmathPr
+\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min27}{\revtim\yr2022\mo4\dy23\hr16\min15}{\version12}{\edmins390}
+{\nofpages13}{\nofwords3869}{\nofchars22058}{\nofcharsws25876}{\vern45}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot1788631 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MbQwNjQ2MjWxsDA2MDdR0lEKTi0uzszPAykwqgUA0yVwxywAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot1788631 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MbQwNjQ2MjWxsDA2MDdR0lEKTi0uzszPAykwrgUAkhRr3iwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11018755 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -135,8 +132,8 @@ d features added to Version 4 was support for non-English versions of Microsoft 
 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "https://dl.dropboxusercontent.com/u/43555945/XASDK60.zip" }{\rtlch\fcs1 \af0 \ltrch\fcs0 
 \insrsid11018755 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a000000680074007400700073003a002f002f0064006c002e00640072006f00700062006f007800750073006500720063006f006e00740065006e0074002e0063006f006d002f0075002f0034003300350035003500
-3900340035002f0058004100530044004b00360030002e007a00690070000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000007c2b7700}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs17\f37\fs22\ul\cf19\insrsid11018755\charrsid3830441 
-\hich\af37\dbch\af31505\loch\f37 https://dl.dropboxuse\hich\af37\dbch\af31505\loch\f37 rcontent.com/u/43555945/XASDK60.zip}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11018755\charrsid3830441 .}
+3900340035002f0058004100530044004b00360030002e007a00690070000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000007c2b770064}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs17\f37\fs22\ul\cf19\insrsid11018755\charrsid3830441 
+\hich\af37\dbch\af31505\loch\f37 https://dl.dropboxus\hich\af37\dbch\af31505\loch\f37 ercontent.com/u/43555945/XASDK60.zip}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11018755\charrsid3830441 .}
 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755 
 \par {\listtext\pard\plain\ltrpar \s18 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 b.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 
 \hich\af37\dbch\af31505\loch\f37 Save the file to your default download folder.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755 
@@ -153,9 +150,9 @@ d features added to Version 4 was support for non-English versions of Microsoft 
 \hich\af37\dbch\af31505\loch\f37 Click }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 Run}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 
 \hich\af37\dbch\af31505\loch\f37 . }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755 
 \par {\listtext\pard\plain\ltrpar \s18 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 f.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 
-\hich\af37\dbch\af31505\loch\f37 Select }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 I accept the terms of this license agreement}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37  and click }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 Next}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 . }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755 
+\hich\af37\dbch\af31505\loch\f37 Select }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 I acc\hich\af37\dbch\af31505\loch\f37 ept the terms of this license agreement}{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37  and click }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 Next}{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 . }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755 
 \par {\listtext\pard\plain\ltrpar \s18 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 g.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 
 \hich\af37\dbch\af31505\loch\f37 Select }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 Update the execution policy (to AllSigned)}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37  and Click }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 Next}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
@@ -179,7 +176,7 @@ update the execution policy to AllSigned, the Citrix supplied XenApp PowerShell 
  Internet browser; go to }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 
  HYPERLINK "https://dl.dropboxusercontent.com/u/43555945/Citrix.GroupPolicy.Commands.zip" }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11018755 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bb2000000680074007400700073003a002f002f0064006c002e00640072006f00700062006f007800750073006500720063006f006e00740065006e0074002e0063006f006d002f0075002f0034003300350035003500
-3900340035002f004300690074007200690078002e00470072006f007500700050006f006c006900630079002e0043006f006d006d0061006e00640073002e007a00690070000000795881f43b1d7f48af2c825dc485276300000000a5ab0000004100000034970000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
+3900340035002f004300690074007200690078002e00470072006f007500700050006f006c006900630079002e0043006f006d006d0061006e00640073002e007a00690070000000795881f43b1d7f48af2c825dc485276300000000a5ab000000410000003497000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \cs17\f37\fs22\ul\cf19\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 https://dl.dropboxusercontent.com/u/43555945/Citrix.GroupPolicy.Commands.zip}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755 
 \par {\listtext\pard\plain\ltrpar \s18 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 b.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 
@@ -210,25 +207,25 @@ Configuration Logging, you will need to use a UDL file in order for the History 
 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "http://tinyurl.com/CreateUDLFile"}{\rtlch\fcs1 \ai\af0 \ltrch\fcs0 \i\insrsid11018755 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5a00000068007400740070003a002f002f00740069006e007900750072006c002e0063006f006d002f00430072006500610074006500550044004c00460069006c0065000000795881f43b1d7f48af2c825dc4852763
-00000000a5ab00000018000000a9000000}}}{\fldrslt {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\ul\cf2\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 http://tinyurl.com/CreateUDLFile}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
+00000000a5ab00000018000000a900000019}}}{\fldrslt {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\ul\cf2\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 http://tinyurl.com/CreateUDLFile}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755 
 \par {\listtext\pard\plain\ltrpar \s18 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 b.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 
 \hich\af37\dbch\af31505\loch\f37 The UDL file will need to be placed in the same folder as the XenApp 6 Inventory script.  The UDL file will need to be named XA6ConfigLog.udl.  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755 
 \par {\listtext\pard\plain\ltrpar \s18 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 c.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 
-\hich\af37\dbch\af31505\loch\f37 You will need to edit the UDL fil\hich\af37\dbch\af31505\loch\f37 e and add  }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 
+\hich\af37\dbch\af31505\loch\f37 You will need to edit the UDL fi\hich\af37\dbch\af31505\loch\f37 le and add  }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 
 ;Password=ConfigLogDatabasePassword}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37  to the end of the last line in the file.  For example, here is mine (line is one line):}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755 
 \par {\listtext\pard\plain\ltrpar \s18 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 i.\tab}}\pard \ltrpar\s18\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid11018755\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 
-Provider=SQLOLEDB.1;Integrated Security=SSPI;Persist Security Info=False;User ID=administrator;Initial Catalog=XA6Conf\hich\af37\dbch\af31505\loch\f37 igLog;Data Source=SQL;Password=abcd1234}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755 
+Provider=SQLOLEDB.1;Integrated Security=SSPI;Persist Security Info=False;User ID=administrator;Initial Catalog=XA6Con\hich\af37\dbch\af31505\loch\f37 figLog;Data Source=SQL;Password=abcd1234}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755 
 
 \par {\listtext\pard\plain\ltrpar \s18 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 4.\tab}}\pard \ltrpar\s18\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid5119476\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 \hich\f37 
 You may want to go to the Citrix Support site for XenApp 6 and check for updates specific to the PowerShell cmdlets or Help Text.  For \'93\loch\f37 \hich\f37 Public Hotfixes for XenApp 6.0 for Windows Server 2008 R2\'94\loch\f37 , see }
-{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "ht\hich\af37\dbch\af31505\loch\f37 tp://tinyurl.com/XA60Updates"}{\rtlch\fcs1 \af0 \ltrch\fcs0 
+{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "h\hich\af37\dbch\af31505\loch\f37 ttp://tinyurl.com/XA60Updates"}{\rtlch\fcs1 \af0 \ltrch\fcs0 
 \insrsid11018755 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5600000068007400740070003a002f002f00740069006e007900750072006c002e0063006f006d002f00580041003600300055007000640061007400650073000000795881f43b1d7f48af2c825dc485276300000000
-a5ab000000df0000004f090075}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\ul\cf2\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 http://tinyurl.com/XA60Updates}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+a5ab000000df0000004f0900756d}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\ul\cf2\insrsid11018755\charrsid3830441 \hich\af37\dbch\af31505\loch\f37 http://tinyurl.com/XA60Updates}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid3830441 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5119476 
 \par {\listtext\pard\plain\ltrpar \s18 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid5119476 \hich\af37\dbch\af31505\loch\f37 5.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755\charrsid5119476 
 \hich\af37\dbch\af31505\loch\f37 To gather software inventory, a file named SoftwareExclusions.txt }{\rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid11018755\charrsid5119476 \hich\af37\dbch\af31505\loch\f37 MUST}{\rtlch\fcs1 \af37\afs22 
@@ -269,34 +266,38 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par \hich\af37\dbch\af31505\loch\f37 Get-Help .\\XA6_Inventory_V}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11894281 \hich\af37\dbch\af31505\loch\f37 43}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11018755 
 \hich\af37\dbch\af31505\loch\f37 .ps1 \hich\f37 \endash \loch\f37 full
 \par \hich\af37\dbch\af31505\loch\f37 The help text explains all the parameters the script accepts.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12391750 
+\par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid13662517 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid685683 \page }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid13662517 \hich\af43\dbch\af31505\loch\f43 Help Text}{\rtlch\fcs1 
+\ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf23\insrsid13662517 
 \par }\pard\plain \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid7758767 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 
-\ltrch\fcs0 \insrsid685683 \page }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 NAME
-\par \hich\af2\dbch\af31505\loch\f2     C:\\PSScript\\XA6_Inventory_V43.ps1
+\ltrch\fcs0 \insrsid13662517 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 NAME
+\par \hich\af2\dbch\af31505\loch\f2     C:\\PSScrip\hich\af2\dbch\af31505\loch\f2 t\\XA6_Inventory_V43.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
-\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Citrix XenApp 6 farm using Microsoft Word 2010}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12204691 \hich\af2\dbch\af31505\loch\f2 , 2013 \hich\af2\dbch\af31505\loch\f2   
+\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Citrix XenApp 6 farm using Microsoft Word 2010}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12204691 \hich\af2\dbch\af31505\loch\f2 , 2013   
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 or 201}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12204691 \hich\af2\dbch\af31505\loch\f2 6}{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 .
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     C:\\PSScript\\XA6_Inventory_V43.ps1 [-MSWord] [-Hardware] [-Software] [-StartDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12204691 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\PSScript\\\hich\af2\dbch\af31505\loch\f2 XA6_Inventory_V43.ps1 [-MSWord] [-Hardware] [-Software] [-StartDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12204691 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-EndDate <DateTime>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12204691 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 [-Summary] [-AddDateTime] [-Sec\hich\af2\dbch\af31505\loch\f2 tion <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 [-Summary] [-AddDateTime] [-Section <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12204691 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 [-Comp\hich\af2\dbch\af31505\loch\f2 anyName <String>] [-CompanyAddress <String>] [-CompanyEmail}{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12204691 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid12204691 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyAddress <String>] [-CompanyEmail}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid12204691 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12204691 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 [-CompanyFax <String>] [-CompanyPhone <String>] [-CoverPage <String>] [-UserName }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid12204691 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12204691 \hich\af2\dbch\af31505\loch\f2  }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\PSScript\\XA6_Inventory_V43.ps1 [-PDF]\hich\af2\dbch\af31505\loch\f2  [-Hardware] [-Software] [-StartDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12204691 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\PSScript\\XA6_Inventory_V43.ps1 [-PDF] [-Hardware] [-Soft\hich\af2\dbch\af31505\loch\f2 ware] [-StartDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12204691 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-EndDate <DateTime>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12204691 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 [-Summary] [-AddDateTime] [-Section <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12204691 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyAddress <String>] [-CompanyEmail}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid12204691 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12204691 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 [-CompanyFax <String>] [-CompanyPhone <String>] [-Cover\hich\af2\dbch\af31505\loch\f2 Page <String>] [-UserName 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 [-CompanyFax <String>] [-CompanyPhone <String>] [-CoverPage <String\hich\af2\dbch\af31505\loch\f2 >] [-UserName 
 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12204691 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12204691 \hich\af2\dbch\af31505\loch\f2  }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
@@ -306,7 +307,7 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Citrix XenApp 6 farm using Microsoft Word and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12204691 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 PowerShell.
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Word document or PDF named after the XenApp 6 farm.
-\par \hich\af2\dbch\af31505\loch\f2     Document includ\hich\af2\dbch\af31505\loch\f2 es a Cover Page, Table of Contents and Footer.
+\par \hich\af2\dbch\af31505\loch\f2     Document includes a C\hich\af2\dbch\af31505\loch\f2 over Page, Table of Contents and Footer.
 \par \hich\af2\dbch\af31505\loch\f2     Version 4.xx includes support for the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
@@ -327,24 +328,24 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Requ\hich\af2\dbch\af31505\loch\f2 ired?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?          \hich\af2\dbch\af31505\loch\f2           false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file\hich\af2\dbch\af31505\loch\f2  instead of DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOC\hich\af2\dbch\af31505\loch\f2 X file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         For Word 2007, the Microsoft add-in for saving as a PDF mu}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 t be installed.
 \par \hich\af2\dbch\af31505\loch\f2         For Word 2007, please see}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 \hich\af2\dbch\af31505\loch\f2   
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=9943"
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=9943" }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid7758767 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9200000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d0039003900340033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs17\f2\fs18\ul\cf19\insrsid7758767\charrsid7758767 
+65007400610069006c0073002e0061007300700078003f00690064003d0039003900340033000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs17\f2\fs18\ul\cf19\insrsid7758767\charrsid7758767 
 \hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.aspx?id=9943}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 The PDF file is roughly 5X to 10X larger than the DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOC\hich\af2\dbch\af31505\loch\f2 X file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -354,56 +355,60 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on: Computer System, Disks, Processor and Network Interface Cards
-\par \hich\af2\dbch\af31505\loch\f2         This parameter\hich\af2\dbch\af31505\loch\f2  is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?\hich\af2\dbch\af31505\loch\f2                     false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Software \hich\af2\dbch\af31505\loch\f2 [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gather software installed by querying the registry.
+\par \hich\af2\dbch\af31505\loch\f2     -Software [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Gather software\hich\af2\dbch\af31505\loch\f2  installed by querying the registry.
 \par \hich\af2\dbch\af31505\loch\f2         Use SoftwareExclusions.txt to exclude software from the report.
 \par \hich\af2\dbch\af31505\loch\f2         SoftwareExclusions.txt must exist, and be readable, in the same folder as this }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 script.
-\par \hich\af2\dbch\af31505\loch\f2         S\hich\af2\dbch\af31505\loch\f2 oftwareExclusions.txt can be an empty file to have no installed applications }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
+\par \hich\af2\dbch\af31505\loch\f2         SoftwareExclusions.txt can be an em\hich\af2\dbch\af31505\loch\f2 pty file to have no installed applications }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 excluded.
 \par \hich\af2\dbch\af31505\loch\f2         See Get-Help About-Wildcards for help on formatting the lines to exclude }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 applications.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?         \hich\af2\dbch\af31505\loch\f2            false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -StartDate <DateTime>
-\par \hich\af2\dbch\af31505\loch\f2         Start date, in MM/DD/YYYY HH:MM format, for the Configuration Logging report.
+\par \hich\af2\dbch\af31505\loch\f2         Start date\hich\af2\dbch\af31505\loch\f2 , in MM/DD/YYYY HH:MM format, for the Configuration Logging report.
 \par \hich\af2\dbch\af31505\loch\f2         The default is today's date minus seven days.
-\par \hich\af2\dbch\af31505\loch\f2         If the StartDate is entered as 01/01/2020, the date becomes 01/01/2020 00:00:00.
+\par \hich\af2\dbch\af31505\loch\f2         If the StartDate is entered as 01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 
+\hich\af2\dbch\af31505\loch\f2 , the date becomes 01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 
+\hich\af2\dbch\af31505\loch\f2  00:00:00.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?         \hich\af2\dbch\af31505\loch\f2            false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                ((Get-Date -displayhint date).AddDays(-7))
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -EndDate <DateTime>
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    End date, in MM/DD/YYYY HH:MM format, for the Configuration Logging report.
+\par \hich\af2\dbch\af31505\loch\f2         End date, in MM\hich\af2\dbch\af31505\loch\f2 /DD/YYYY HH:MM format, for the Configuration Logging report.
 \par \hich\af2\dbch\af31505\loch\f2         The default is today's date.
-\par \hich\af2\dbch\af31505\loch\f2         If the EndDate is entered as 01/01/2020, the date becomes 01/01/2020 00:00:00.
+\par \hich\af2\dbch\af31505\loch\f2         If the EndDate is entered as 01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 
+\hich\af2\dbch\af31505\loch\f2 , the date becomes 01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 
+\hich\af2\dbch\af31505\loch\f2  00:00:00.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         P\hich\af2\dbch\af31505\loch\f2 osition?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?          \hich\af2\dbch\af31505\loch\f2           named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                (Get-Date -displayhint date)
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Summary [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Only give summary informatio\hich\af2\dbch\af31505\loch\f2 n, no details.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         Only give summary information, no details.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter cannot be used with either the Hardware, Software, StartDate or }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 EndDate parameters.
 \par 
@@ -414,26 +419,28 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of t\hich\af2\dbch\af31505\loch\f2 he file name.
 \par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2         June 1, 2020 at 6PM is 2020-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2020-06-01_1800.docx (or .pdf).
-\par \hich\af2\dbch\af31505\loch\f2         This para\hich\af2\dbch\af31505\loch\f2 meter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 
+ at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 
+\hich\af2\dbch\af31505\loch\f2 -06-01_1800.docx (or .pdf).
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Require\hich\af2\dbch\af31505\loch\f2 d?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Sect\hich\af2\dbch\af31505\loch\f2 ion <String>
-\par \hich\af2\dbch\af31505\loch\f2         Processes a specific section of the report.
+\par \hich\af2\dbch\af31505\loch\f2     -Section <String>
+\par \hich\af2\dbch\af31505\loch\f2         Processes a specific sect\hich\af2\dbch\af31505\loch\f2 ion of the report.
 \par \hich\af2\dbch\af31505\loch\f2         Valid options are:
 \par \hich\af2\dbch\af31505\loch\f2                 Admins (Administrators)
 \par \hich\af2\dbch\af31505\loch\f2                 Apps (Applications)
 \par \hich\af2\dbch\af31505\loch\f2                 ConfigLog (Configuration Logging)
-\par \hich\af2\dbch\af31505\loch\f2                 LBPolicies (Load Balan\hich\af2\dbch\af31505\loch\f2 cing Policies)
-\par \hich\af2\dbch\af31505\loch\f2                 LoadEvals (Load Evaluators)
+\par \hich\af2\dbch\af31505\loch\f2                 LBPolicies (Load Balancing Policies)
+\par \hich\af2\dbch\af31505\loch\f2                 LoadEvals (Load\hich\af2\dbch\af31505\loch\f2  Evaluators)
 \par \hich\af2\dbch\af31505\loch\f2                 Policies
 \par \hich\af2\dbch\af31505\loch\f2                 Servers
 \par \hich\af2\dbch\af31505\loch\f2                 WGs (Worker Groups)
@@ -445,50 +452,50 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                All
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters? \hich\af2\dbch\af31505\loch\f2  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
+\par \hich\af2\dbch\af31505\loch\f2         Company \hich\af2\dbch\af31505\loch\f2 Name to use for the Cover Page.
 \par \hich\af2\dbch\af31505\loch\f2         Default value is contained in }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whicheve\hich\af2\dbch\af31505\loch\f2 r is populated }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 on the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 computer running the script.
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 computer r\hich\af2\dbch\af31505\loch\f2 unning the script.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
 \par \hich\af2\dbch\af31505\loch\f2                 The following Cover Pages have an Address field:
-\par \hich\af2\dbch\af31505\loch\f2                         Band\hich\af2\dbch\af31505\loch\f2 ed (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                         Banded (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                         Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                         Exposure (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                         Filigree (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                         Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                         Retrospect (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                         Semaphore (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2             Semaphore (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                         Tiles (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                         ViewMaster (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PD\hich\af2\dbch\af31505\loch\f2 F output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fal\hich\af2\dbch\af31505\loch\f2 se
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Email to use for \hich\af2\dbch\af31505\loch\f2 the Cover Page, if the Cover Page has the Email field.
 \par \hich\af2\dbch\af31505\loch\f2                 The following Cover Pages have an Email field:
 \par \hich\af2\dbch\af31505\loch\f2                         Facet (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is o\hich\af2\dbch\af31505\loch\f2 nly valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         Thi\hich\af2\dbch\af31505\loch\f2 s parameter has an alias of CE.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -500,25 +507,25 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
 \par \hich\af2\dbch\af31505\loch\f2                 The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                         Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                         Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2                   Exposure (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page, if the Cover Page has the P\hich\af2\dbch\af31505\loch\f2 hone field.
-\par \hich\af2\dbch\af31505\loch\f2                 The following Cover Pages have a Phone field:
+\par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page, if the Cover Page has the Phone field.
+\par \hich\af2\dbch\af31505\loch\f2                 The following Cover Pag\hich\af2\dbch\af31505\loch\f2 es have a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                         Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                         Exposure (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This\hich\af2\dbch\af31505\loch\f2  parameter has an alias of CPh.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required? \hich\af2\dbch\af31505\loch\f2                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -531,8 +538,8 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par 
 \par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 Valid input is:
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Alphabet (Word 2010. Works)
-\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Annual\hich\af2\dbch\af31505\loch\f2  (Word 2010. Doesn't work well for this report)
-\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Austere (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Annual (Word 2010. Doesn't work well for this report)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Austere \hich\af2\dbch\af31505\loch\f2 (Word 2010. Works)
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly 
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 works in 2010 but Subtitle/Subject & Author fields need to be moved 
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 after title box is moved up)
@@ -542,31 +549,31 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Cubicles (Word 2010. Works)
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Exposure (Word 2010. Works if you like looking sideways)
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Facet (Word 2013/2016. Works)
-\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Filig\hich\af2\dbch\af31505\loch\f2 ree (Word 2013/2016. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Filigree (Word 2013/2016. Works)
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Grid (Word 2010/2013/2016. Works in 2010)
-\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Integral (Word 2013/2016. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Integral (Word 2013/201\hich\af2\dbch\af31505\loch\f2 6. Works)
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be 
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 manually resized or font changed to 8 point)
-\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Ion (Light) (Word 2013/2016. To\hich\af2\dbch\af31505\loch\f2 p date doesn't fit; box needs to be 
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be 
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 manually resized or font changed to 8 point)
-\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Mod (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Mod (Word 2\hich\af2\dbch\af31505\loch\f2 010. Works)
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Motion (Word 2010/2013/2016. Works if top date is manually changed to 
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 36 point)
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Newsprint (Word 2010. Works but date is not populated)
-\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Per\hich\af2\dbch\af31505\loch\f2 spective (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Perspective (Word 2010. Works)
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Pinstripes (Word 2010. Works)
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually 
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 resized or font changed to 14 point)
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Retrospect (Word 2013/2016. Works)
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Semaphore (Word 2013/2016. Works)
-\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Sideline (Wor\hich\af2\dbch\af31505\loch\f2 d 2010/2013/2016. Doesn't work in 2013 or 2016, works in 
-\par \tab \tab \hich\af2\dbch\af31505\loch\f2 2010)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in 
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 20\hich\af2\dbch\af31505\loch\f2 10)
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Slice (Dark) (Word 2013/2016. Doesn't work)
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Slice (Light) (Word 2013/2016. Doesn't work)
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Stacks (Word 2010. Works)
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Transcend (Word 2010. Works)
-\par \tab \tab \hich\af2\dbch\af31505\loch\f2 ViewMaster (Word 2013/2016. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 ViewMaster (Word 2013/2016. Works\hich\af2\dbch\af31505\loch\f2 )
 \par \tab \tab \hich\af2\dbch\af31505\loch\f2 Whisp (Word 2013/2016. Works)}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
@@ -574,26 +581,26 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                  \hich\af2\dbch\af31505\loch\f2   named
+\par \hich\af2\dbch\af31505\loch\f2         Positio\hich\af2\dbch\af31505\loch\f2 n?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
 \par \hich\af2\dbch\af31505\loch\f2         User name to use for the Cover Page and Footer.
-\par \hich\af2\dbch\af31505\loch\f2         The default value is contain\hich\af2\dbch\af31505\loch\f2 ed in $env:username
+\par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $env:username
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipe\hich\af2\dbch\af31505\loch\f2 line input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
 \par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable.\hich\af2\dbch\af31505\loch\f2  For more information, see
+\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVa\hich\af2\dbch\af31505\loch\f2 riable, and OutVariable. For more information, see
 \par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
@@ -601,31 +608,31 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
-\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a Word or PDF d\hich\af2\dbch\af31505\loch\f2 ocument.
+\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script\hich\af2\dbch\af31505\loch\f2  creates a Word or PDF document.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: XA6_Inventory_V43.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 4.34
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 4.3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 5}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster (with a lot of help from Michael B. Smith, Jeff Wouters and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 Iain Brighton)
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: May 9, 2020
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 April 23, 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XA6_Inventory_V43.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="C\hich\af2\dbch\af31505\loch\f2 arl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Nam\hich\af2\dbch\af31505\loch\f2 e.
 \par 
 \par 
 \par 
@@ -634,13 +641,13 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XA6_Inventory_V43.ps1 -PDF
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as \hich\af2\dbch\af31505\loch\f2 a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserIn\hich\af2\dbch\af31505\loch\f2 fo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Com\hich\af2\dbch\af31505\loch\f2 pany Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -652,13 +659,13 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XA65_Inventory_V43.ps1 -Summary
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Summary report with no detail.
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     Wi\hich\af2\dbch\af31505\loch\f2 ll use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Softwar\hich\af2\dbch\af31505\loch\f2 e\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl\hich\af2\dbch\af31505\loch\f2  Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -671,14 +678,14 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Summary report with no detail.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\U\hich\af2\dbch\af31505\loch\f2 serInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Of\hich\af2\dbch\af31505\loch\f2 fice\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator\hich\af2\dbch\af31505\loch\f2  for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
 \par 
@@ -690,8 +697,8 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and add additional information for each server about its }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 hardware.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -703,61 +710,72 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C\hich\af2\dbch\af31505\loch\f2 :\\PSScript >.\\XA6_Inventory_V43.ps1 -StartDate "01/01/2020" -EndDate "01/02/2020"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XA6_Inventory_V43.ps1 -StartDate "01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 " -EndDate "01/02/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 "
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and add additional information for each server about its }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 installed applications.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserI\hich\af2\dbch\af31505\loch\f2 nfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 i\hich\af2\dbch\af31505\loch\f2 nstalled applications.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Web\hich\af2\dbch\af31505\loch\f2 ster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     Will return all Configuration Logging entries from "01/01/2020 00:00:00" through }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 "01/02/2020 "00:00:00".
+\par \hich\af2\dbch\af31505\loch\f2     Will return all Configuration Logging entries from "01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2  00:00:00" through }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 "01/02/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2  "00:00:00".
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXA\hich\af2\dbch\af31505\loch\f2 MPLE 7 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XA6_Inventory_V43.ps1 -StartDate "01/01/2020" -EndDate "01/01/2020"
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and add additional information for each server about its }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 installed applications.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\C\hich\af2\dbch\af31505\loch\f2 ommon\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Admini\hich\af2\dbch\af31505\loch\f2 strator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     Will return all Configuration Logging entries from "01/01/2020 00:00:00" through }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 "01/01/2020 "00:00:00".  In other}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 words, nothing is returned.
-\par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     P\hich\af2\dbch\af31505\loch\f2 S C:\\PSScript >.\\XA6_Inventory_V43.ps1 -StartDate "01/01/2020 21:00:00" -EndDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 "01/01/2020 22:00:00"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XA6_Inventory_V43.ps1 -StartDate "01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 " -EndDate "01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 "
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and add additional information for each server about its }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 installed applications.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\C\hich\af2\dbch\af31505\loch\f2 ommon\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Na\hich\af2\dbch\af31505\loch\f2 me.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     Will return all Configuration Logging entries from 9PM to 10PM \hich\af2\dbch\af31505\loch\f2 on 01/01/2020.
+\par \hich\af2\dbch\af31505\loch\f2     Will return all Configuration Logging entries from "01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2  00:00:00" through }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 "01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2  "00:00:00".  In other}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 words, nothing is returned.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ---------------\hich\af2\dbch\af31505\loch\f2 ----------- EXAMPLE 8 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XA6_Inventory_V43.ps1 -StartDate "01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2  21:00:00" -EndDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 "01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2  22:00:00"
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and add additional information for each server about its }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 installed applications.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl \hich\af2\dbch\af31505\loch\f2 Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Will return all Configuration Logging entries from 9PM to 10PM on 01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid7758767\charrsid7758767 .
 \par 
 \par 
 \par 
@@ -769,7 +787,7 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webst\hich\af2\dbch\af31505\loch\f2 er Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for \hich\af2\dbch\af31505\loch\f2 the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par 
@@ -778,7 +796,7 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XA6_Inventory_V43.ps1 -CN "Carl Webster\hich\af2\dbch\af31505\loch\f2  Consulting" -CP "Mod" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 \hich\af2\dbch\af31505\loch\f2     
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XA6_Inventory_V43.ps1 -CN "Carl Webster Consulting" -CP "\hich\af2\dbch\af31505\loch\f2 Mod" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 \hich\af2\dbch\af31505\loch\f2     
 
 \par \hich\af2\dbch\af31505\loch\f2     -}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 UN "Carl Webster"
 \par 
@@ -795,55 +813,55 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XA6_Inventory_V43.ps1 -CompanyName "Sherlock Holmes }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 Consulting" `
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure -UserName "D\hich\af2\dbch\af31505\loch\f2 r. Watson" `
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress "221B Baker Street, London, England" `
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure -UserName "Dr. Watson" `
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress "221B Baker Stree\hich\af2\dbch\af31505\loch\f2 t, London, England" `
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax "+44 1753 276600" `
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone "+44 1753 276200"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page form\hich\af2\dbch\af31505\loch\f2 at.
+\par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 221B Baker Street, London, England for the Company Address.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
-\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Comp\hich\af2\dbch\af31505\loch\f2 a}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 \hich\af2\dbch\af31505\loch\f2 n}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 y Phone.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Compa}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 \hich\af2\dbch\af31505\loch\f2 n}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 
+\hich\af2\dbch\af31505\loch\f2 y Phone.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XA6_Inventory_V43.ps1 -CompanyName "Sherlock Holmes }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XA\hich\af2\dbch\af31505\loch\f2 6_Inventory_V43.ps1 -CompanyName "Sherlock Holmes }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 Consulting" 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 -UserName "Dr. Watson" 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail SuperSleuth@SherlockHolmes.\hich\af2\dbch\af31505\loch\f2 com
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail SuperSleuth@SherlockHolmes.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Comp\hich\af2\dbch\af31505\loch\f2 a}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 \hich\af2\dbch\af31505\loch\f2 n}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 y Email.
+\par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Compa}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 \hich\af2\dbch\af31505\loch\f2 n}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 
+\hich\af2\dbch\af31505\loch\f2 y Email.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAM\hich\af2\dbch\af31505\loch\f2 PLE 13 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XA6_Inventory_V43.ps1 -Section Policies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Offi\hich\af2\dbch\af31505\loch\f2 ce\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     Processes only the Policies section of the re\hich\af2\dbch\af31505\loch\f2 port.
+\par \hich\af2\dbch\af31505\loch\f2     Processes only the Policies section of the report.
 \par 
 \par 
 \par 
@@ -854,18 +872,20 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 Webster"\hich\af2\dbch\af31505\loch\f2  or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Adds a da\hich\af2\dbch\af31505\loch\f2 te time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, 2020 at 6PM is 2020-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be\hich\af2\dbch\af31505\loch\f2  XA6FarmName_2020-06-01_1800.docx
+\par \hich\af2\dbch\af31505\loch\f2     June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 
+ at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XA6FarmName_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 
+\hich\af2\dbch\af31505\loch\f2 -06-01_1800.docx
 \par 
 \par 
 \par 
@@ -878,17 +898,19 @@ PDF option, a PDF file is created named after the XenApp 6 Farm.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $e\hich\af2\dbch\af31505\loch\f2 nv:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     Will display verbose messages as the script is running.
+\par \hich\af2\dbch\af31505\loch\f2     Wi\hich\af2\dbch\af31505\loch\f2 ll display verbose messages as the script is running.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file \hich\af2\dbch\af31505\loch\f2 name.
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, 2020 at 6PM is 2020-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XA6FarmName_2020-06-01_1800.pdf
+\par \hich\af2\dbch\af31505\loch\f2     June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 
+ at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XA6FarmName_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11631936 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7758767\charrsid7758767 
+\hich\af2\dbch\af31505\loch\f2 -06-0\hich\af2\dbch\af31505\loch\f2 1_1800.pdf
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
 \par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
@@ -1010,10 +1032,10 @@ fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000504c
-686c1d26d60103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000504c686c1d26d601
-504c686c1d26d6010000000000000000000000003400d400d800d6004b00d400c900cb004f00c40047003100430051005300cd0058004300df00d800d70041003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000504c686c1d26
-d601504c686c1d26d6010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000d093
+58385757d80103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000d09358385757d801
+d09358385757d8010000000000000000000000003400d400d800d6004b00d400c900cb004f00c40047003100430051005300cd0058004300df00d800d70041003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000d09358385757
+d801d09358385757d8010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
 00000000000000000000000000000000320100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/XenApp6_Script_ChangeLog.txt
+++ b/XenApp6_Script_ChangeLog.txt
@@ -4,6 +4,28 @@
 #http://www.CarlWebster.com
 #originally released to the Citrix community on September 30, 2011
 
+#Version 4.35 23-Apr-2022
+#	Change all Get-WMIObject to Get-CIMInstance
+#	Fixed numerous $Null comparisons
+#	Fixed the German Table of Contents (Thanks to Rene Bigler)
+#		From 
+#			'de-'	{ 'Automatische Tabelle 2'; Break }
+#		To
+#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
+#	General code cleanup
+#	In Function AbortScript, add test for the winword process and terminate it if it is running
+#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
+#	In Function OutputNicItem, fixed several issues with DHCP data
+#	Updated the following functions to the latest version:
+#		AddWordTable
+#		Check-LoadedModule
+#		Check-NeededPSSnapins
+#		SetWordCellFormat
+#		UpdateDocumentProperties
+#		validStateProp
+#	Updated the help text
+#	Updated the ReadMe file
+
 #Version 4.34 9-May-2020
 #	Add checking for a Word version of 0, which indicates the Office installation needs repairing
 #	Add Receive Side Scaling setting to Function OutputNICItem


### PR DESCRIPTION
#Version 4.35 23-Apr-2022
#	Change all Get-WMIObject to Get-CIMInstance
#	Fixed numerous $Null comparisons
#	Fixed the German Table of Contents (Thanks to Rene Bigler)
#		From 
#			'de-'	{ 'Automatische Tabelle 2'; Break }
#		To
#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
#	General code cleanup
#	In Function AbortScript, add test for the winword process and terminate it if it is running
#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
#	In Function OutputNicItem, fixed several issues with DHCP data
#	Updated the following functions to the latest version:
#		AddWordTable
#		Check-LoadedModule
#		Check-NeededPSSnapins
#		SetWordCellFormat
#		UpdateDocumentProperties
#		validStateProp
#	Updated the help text
#	Updated the ReadMe file